### PR TITLE
base_ops: use crate csv to replace simdcsv

### DIFF
--- a/crates/base_ops/Cargo.toml
+++ b/crates/base_ops/Cargo.toml
@@ -21,6 +21,7 @@ btoi = "0.4"
 chrono = "0.4"
 itoa = "0.4"
 bytes = "0.5.6"
+csv = "1.1.5"
 
 [build-dependencies]
 cmake = "0.1"

--- a/crates/base_ops/src/baseops.rs
+++ b/crates/base_ops/src/baseops.rs
@@ -27,7 +27,7 @@ use std::{fs, path::Path};
     version = "0.1",
     author = "TensorBase, and its contributors",
     about = "TensorBase Devops Tool(Early Preview)",
-    set_term_width = 80
+    max_term_width = 80
 )]
 struct Opts {
     // /// [TODO]Optionally specify a custom config file.


### PR DESCRIPTION
Finally, I reproduce the base benchmarks with ClickHouse.

It shows `tensorbase` outperforms `ClickHouse` by 1.x - 2.x.   

Yet there are some bugs to fix for others to try `tensorbase`.


Results:
```
[query]>select count(trip_id - 100  )  from  nyc_taxi;
kernel exec time: 225.380904ms
843646163758811010
query response time: 225.492269ms



:) select sum(trip_id -100 )  from  nyc_taxi;  -- 3 partition

SELECT sum(trip_id - 100)
FROM nyc_taxi

Query id: e9eb9ccf-8f47-42d7-9fe6-89e10faaec19

┌─sum(minus(trip_id, 100))─┐
│       843673733667788365 │
└──────────────────────────┘

1 rows in set. Elapsed: 0.748 sec. Processed 1.30 billion rows, 5.20 GB (1.74 billion rows/s., 6.95 GB/s.)
```


datas in ClickHouse, 3 partitions

```
>  du -sh data/datasets/nyc_taxi/*
4.1G    data/datasets/nyc_taxi/0_3_3558_5
4.1G    data/datasets/nyc_taxi/1_1_3556_5
4.1G    data/datasets/nyc_taxi/2_2_3557_5
4.0K    data/datasets/nyc_taxi/detached
4.0K    data/datasets/nyc_taxi/format_version.txt
```

datas in tensorbase
```
> ll -sh  /data/n3/data
total 11G
4.9G -rw-r--r-- 1 root root 4.9G 1月   9 11:25 0
4.9G -rw-r--r-- 1 root root 4.9G 1月   9 11:25 1
1.3G -rw-r--r-- 1 root root 1.3G 1月   9 11:25 2

```