### PR TITLE
fix warnings

### DIFF
--- a/crates/base/src/datetimes.rs
+++ b/crates/base/src/datetimes.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, NaiveDate, NaiveDateTime};
+use chrono::{Datelike, NaiveDate};
 use num_integer::Integer;
 use num_traits::ToPrimitive;
 
@@ -84,7 +84,7 @@ pub fn parse_to_epoch(s: &str) -> BaseResult<u32> {
 mod unit_tests {
     use super::*;
     use crate::show_option_size;
-    use chrono::{prelude::*, Duration};
+    use chrono::prelude::*;
 
     #[test]
     fn basic_check() -> BaseResult<()> {

--- a/crates/base/src/hash.rs
+++ b/crates/base/src/hash.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 pub trait Hasher {
     fn hash(&self) -> u64;
 }

--- a/crates/base/src/mmap.rs
+++ b/crates/base/src/mmap.rs
@@ -2,8 +2,6 @@ use std::io::Error;
 
 use crate::mem::MemAddr;
 
-use libc::c_void;
-
 use crate::errs::{BaseError, BaseResult};
 
 #[inline]
@@ -85,6 +83,7 @@ pub fn mm_unmap(addr: MemAddr, size: usize) -> BaseResult<()> {
 #[cfg(test)]
 mod unit_tests {
     use std::{env, ffi::CString, fs, io::Error};
+    use libc::c_void;    
 
     use super::*;
 

--- a/crates/engine/src/datafusions.rs
+++ b/crates/engine/src/datafusions.rs
@@ -1,23 +1,21 @@
-use std::{collections::{HashMap, HashSet}, lazy::SyncLazy, sync::{Arc, Mutex}, time::Instant};
+use std::{collections::HashSet, lazy::SyncLazy, sync::Arc};
 
 use arrow::{
     array::{
-        ArrayData, ArrayRef, Date32Array, Int8Array, Int16Array, Int32Array,
-        Int64Array, PrimitiveArray, Time32SecondArray, Timestamp32Array,
-        TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array,
-        UInt64Array,
+        ArrayData, ArrayRef, Int8Array, Int16Array, Int32Array,
+        Int64Array, Timestamp32Array, UInt8Array, UInt16Array, 
+        UInt32Array, UInt64Array,
     },
     buffer::Buffer,
     datatypes::{
-        ArrowPrimitiveType, DataType, Field, Int8Type, Schema, TimeUnit,
+        DataType, Field, Schema, 
     },
     ffi::FFI_ArrowArray,
     record_batch::RecordBatch,
 };
 use datafusion::{
     datasource::MemTable,
-    error::{DataFusionError, Result},
-    physical_plan::collect,
+    error::Result,
     prelude::ExecutionContext,
 };
 use meta::{
@@ -25,7 +23,7 @@ use meta::{
         parts::{CoPaInfo, PartStore},
         sys::MetaStore,
     },
-    types::{BqlType, ColumnInfo, Id},
+    types::{BqlType, Id},
 };
 use tokio::runtime::{self, Runtime};
 
@@ -59,7 +57,7 @@ pub(crate) fn run(
     ps: &PartStore,
     current_db: &str,
     raw_query: &str,
-    query_id: &str,
+    _query_id: &str,
     tabs: HashSet<String>,
     cols: HashSet<String>,
     qs: &mut QueryState,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -16,6 +16,7 @@ pub fn run(
     current_db: &str,
     p: Pair<Rule>,
     raw_query: &str,
+    // TODO Don't actually use this for anything
     query_id: &str,
     qs: &mut QueryState,
 ) -> EngineResult<Vec<RecordBatch>> {

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -1,13 +1,8 @@
-use std::time::Instant;
-
-use base::mmap::mm_unmap;
-use libc::c_void;
 use meta::{
-    store::parts::{CoPaInfo, PartStore},
+    store::parts::CoPaInfo,
     types::{BqlType, Id},
 };
 
-use crate::errs::{EngineError, EngineResult};
 
 pub trait IQueryState {
 }

--- a/crates/lightjit/src/builtins.rs
+++ b/crates/lightjit/src/builtins.rs
@@ -1,16 +1,19 @@
 use base::datetimes::unixtime_to_ymd;
 
 //FIXME expensive a little
+#[allow(non_snake_case)]
 pub fn toYYYY(ut: u64) -> u64 {
     let ymd = unixtime_to_ymd(ut as i32);
     ymd.y as u64
 }
 
+#[allow(non_snake_case)]
 pub fn toYYYYMM(ut: u64) -> u64 {
     let ymd = unixtime_to_ymd(ut as i32);
     ymd.y as u64 * 100 + ymd.m as u64
 }
 
+#[allow(non_snake_case)]
 pub fn toYYYYMMDD(ut: u64) -> u64 {
     let ymd = unixtime_to_ymd(ut as i32);
     ymd.y as u64 * 10000 + ymd.m as u64 * 100 + ymd.d as u64

--- a/crates/meta/src/confs.rs
+++ b/crates/meta/src/confs.rs
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 
 //NAIVE just PoC?
-use base::{debug, fs::validate_path};
+use base::{fs::validate_path};
 use serde::{Deserialize, Serialize};
-use std::{env, fs, ops::Deref, path::PathBuf};
+use std::{env, fs};
 
 use crate::errs::{MetaError, MetaResult};
 

--- a/crates/meta/src/store/parts.rs
+++ b/crates/meta/src/store/parts.rs
@@ -250,7 +250,7 @@ impl<'a> PartStore<'a> {
 
     //FIXME to rework
     //TODO
-    pub fn uncache_for_table(&self, tid: Id, cids: &[Id]) -> MetaResult<()> {
+    pub fn uncache_for_table(&self, _tid: Id, _cids: &[Id]) -> MetaResult<()> {
         Ok(())
     }
 
@@ -392,16 +392,15 @@ fn open(path: &CStr) -> MetaResult<u32> {
 
 #[cfg(test)]
 mod unit_tests {
-    use base::seq;
     use baselog::{
-        Config, ConfigBuilder, LevelFilter, TermLogger, TerminalMode,
+        ConfigBuilder, LevelFilter, TermLogger, TerminalMode,
     };
     use walkdir::WalkDir;
 
     use super::*;
     use crate::errs::MetaResult;
     use std::path::Path;
-    use std::{env::temp_dir, fs::create_dir_all};
+    use std::fs::create_dir_all;
     use std::{fs::remove_dir_all, time::Instant};
 
     fn prepare_dirs(tmp_dir: &str) -> MetaResult<(String, String)> {

--- a/crates/meta/src/store/sys.rs
+++ b/crates/meta/src/store/sys.rs
@@ -57,7 +57,6 @@ use crate::to_qualified_key;
 use crate::errs::{MetaError, MetaResult};
 use crate::types::*;
 
-use base::bytes_cat;
 use num_traits::PrimInt;
 pub use sled::IVec;
 
@@ -86,13 +85,13 @@ impl MetaStore {
             .path(p0)
             .cache_capacity(64 * 1024 * 1024)
             .open()
-            .map_err(|e| MetaError::OpenError)?;
-        let tree0 = mdb.open_tree(b"0").map_err(|e| MetaError::OpenError)?;
-        let tree1 = mdb.open_tree(b"1").map_err(|e| MetaError::OpenError)?;
+            .map_err(|_e| MetaError::OpenError)?;
+        let tree0 = mdb.open_tree(b"0").map_err(|_e| MetaError::OpenError)?;
+        let tree1 = mdb.open_tree(b"1").map_err(|_e| MetaError::OpenError)?;
         let tree_tabs =
-            mdb.open_tree(b"ts").map_err(|e| MetaError::OpenError)?;
+            mdb.open_tree(b"ts").map_err(|_e| MetaError::OpenError)?;
         let tree_cols =
-            mdb.open_tree(b"cs").map_err(|e| MetaError::OpenError)?;
+            mdb.open_tree(b"cs").map_err(|_e| MetaError::OpenError)?;
         Ok(MetaStore {
             mdb,
             tree0,
@@ -150,7 +149,7 @@ impl MetaStore {
     //FIXME assumed the idgen can be recovered, but we still need a
     //      manual recovery mech which could be done in housekeeping
     fn gen_id(&self) -> MetaResult<Id> {
-        self.mdb.generate_id().map_err(|e| MetaError::IdGenError)
+        self.mdb.generate_id().map_err(|_e| MetaError::IdGenError)
     }
 
     ///WARN this api assumes the name are qualified name and validated before passing
@@ -194,13 +193,13 @@ impl MetaStore {
                 let _old = self
                     .tree0
                     .insert(ks, id.as_bytes())
-                    .map_err(|e| MetaError::InsertError)?;
+                    .map_err(|_e| MetaError::InsertError)?;
                 debug_assert!(_old.is_none());
                 //tree1
                 let _old = self
                     .tree1
                     .insert(id.to_be_bytes(), ks)
-                    .map_err(|e| MetaError::InsertError)?;
+                    .map_err(|_e| MetaError::InsertError)?;
                 debug_assert!(_old.is_none());
                 // if let Some(old_value) = r {
                 //     let bs = &*old_value;
@@ -224,7 +223,7 @@ impl MetaStore {
         let _old = self
             .tree0
             .insert(key_sd, dbname)
-            .map_err(|e| MetaError::InsertError)?;
+            .map_err(|_e| MetaError::InsertError)?;
         debug_assert!(_old.is_none());
         Ok(rt)
     }
@@ -540,7 +539,7 @@ impl MetaStore {
         let mut key: Vec<u8> = Vec::with_capacity(16);
         key.extend_from_slice(to_key_id_order(tid).as_bytes());
         key.extend_from_slice(k.as_bytes());
-        self.tree_tabs.get(key).map_err(|e| MetaError::GetError)
+        self.tree_tabs.get(key).map_err(|_e| MetaError::GetError)
     }
 
     fn get_table_info_engine(&self, tid: Id) -> MetaResult<EngineType> {
@@ -556,7 +555,7 @@ impl MetaStore {
         let mut key: Vec<u8> = Vec::with_capacity(16);
         key.extend_from_slice(to_key_id_order(tid).as_bytes());
         key.extend_from_slice(k.as_bytes());
-        let r = self.tree_tabs.get(key).map_err(|e| MetaError::GetError)?;
+        let r = self.tree_tabs.get(key).map_err(|_e| MetaError::GetError)?;
         if let Some(iv) = r {
             let bs = &*iv;
             if bs.len() == std::mem::size_of::<T>() {
@@ -584,7 +583,7 @@ impl MetaStore {
         let r = self
             .tree_tabs
             .insert(key, v.as_bytes())
-            .map_err(|e| MetaError::InsertError)?;
+            .map_err(|_e| MetaError::InsertError)?;
         if r.is_some() {
             log::info!("{:?}", r.as_ref().unwrap());
         }
@@ -608,7 +607,7 @@ impl MetaStore {
         let r = self
             .tree_cols
             .insert(k.as_slice(), v.as_slice())
-            .map_err(|e| MetaError::InsertError)?;
+            .map_err(|_e| MetaError::InsertError)?;
         debug_assert!(r.is_none());
 
         if is_index_needed {
@@ -619,7 +618,7 @@ impl MetaStore {
             let r = self
                 .tree_cols
                 .insert(k.as_slice(), &[])
-                .map_err(|e| MetaError::InsertError)?;
+                .map_err(|_e| MetaError::InsertError)?;
             debug_assert!(r.is_none());
         }
         Ok(())
@@ -675,7 +674,7 @@ impl MetaStore {
         let r = self
             .tree_cols
             .get(&cid.to_be_bytes())
-            .map_err(|e| MetaError::InsertError)?;
+            .map_err(|_e| MetaError::InsertError)?;
         if let Some(iv) = r {
             let bs = &*iv;
             if std::mem::size_of::<ColumnInfo>() == bs.len() {
@@ -936,7 +935,7 @@ mod unit_tests {
         // .scan_prefix(to_key_id_order(3).as_bytes());
         // println!("res.count: {}", res.by_ref());
         for r in res {
-            let (k, v) = r.map_err(|_| MetaError::InsertError)?;
+            let (k, _v) = r.map_err(|_| MetaError::InsertError)?;
             // println!(
             //     "k: {:?}, v: {:?}",
             //     // unsafe { std::str::from_utf8_unchecked(&*k) },

--- a/crates/meta/src/types.rs
+++ b/crates/meta/src/types.rs
@@ -199,21 +199,21 @@ impl BqlType {
                         .next()
                         .ok_or(MetaError::UnknownBqlTypeConversionError)?,
                 )
-                .map_err(|e| MetaError::UnknownBqlTypeConversionError)?;
+                .map_err(|_e| MetaError::UnknownBqlTypeConversionError)?;
                 let s0 = str::from_utf8(
                     ps_iter
                         .next()
                         .ok_or(MetaError::UnknownBqlTypeConversionError)?,
                 )
-                .map_err(|e| MetaError::UnknownBqlTypeConversionError)?;
+                .map_err(|_e| MetaError::UnknownBqlTypeConversionError)?;
                 let p = p0
                     .trim()
                     .parse::<u8>()
-                    .map_err(|e| MetaError::UnknownBqlTypeConversionError)?;
+                    .map_err(|_e| MetaError::UnknownBqlTypeConversionError)?;
                 let s = s0
                     .trim()
                     .parse::<u8>()
-                    .map_err(|e| MetaError::UnknownBqlTypeConversionError)?;
+                    .map_err(|_e| MetaError::UnknownBqlTypeConversionError)?;
                 //FIXME stronger validations
                 Ok(BqlType::Decimal(p, s))
             }

--- a/crates/runtime/src/ch/blocks.rs
+++ b/crates/runtime/src/ch/blocks.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryFrom, slice};
 
 use arrow::{
-    datatypes::{DataType, TimeUnit},
+    datatypes::DataType,
     record_batch::RecordBatch,
 };
 use bytes::{Buf, BufMut, BytesMut};
@@ -566,7 +566,7 @@ impl BytesDecoder<Column> for &[u8] {
                 let ndict = self.get_u64_le();
                 //consume whole dict,a.k.a. gen offset_map
                 let mut os_map = vec![];
-                let mut oss = self.as_ptr();
+                let oss = self.as_ptr();
                 for i in 0..ndict {
                     let os = unsafe { self.as_ptr().offset_from(oss) } as u32;
                     os_map.push(os);

--- a/crates/runtime/src/ch/messages.rs
+++ b/crates/runtime/src/ch/messages.rs
@@ -1,6 +1,6 @@
 use bytes::{Buf, BufMut, BytesMut};
 use lzzzz::lz4;
-use std::{slice, str};
+use std::str;
 
 use crate::{
     mgmt::{BaseCommandKind, BMS},
@@ -15,8 +15,6 @@ use crate::ch::protocol::{
 use crate::errs::{BaseRtError, BaseRtResult};
 
 use super::{
-    blocks::Column,
-    codecs::BytesDecoder,
     protocol::{StageKind, LZ4_COMPRESSION_METHOD},
 };
 

--- a/crates/runtime/src/errs.rs
+++ b/crates/runtime/src/errs.rs
@@ -1,4 +1,3 @@
-use engine::errs::EngineError;
 use thiserror::Error;
 
 /// Result type

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, unused_variables, unused_macros)]
-#![feature(once_cell, or_patterns, thread_local, core_intrinsics)]
+#![feature(once_cell, thread_local, core_intrinsics)]
 
 pub mod errs;
 pub mod mgmt;

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -3,7 +3,6 @@ use bytes::BytesMut;
 use chrono::{Local, Offset, TimeZone};
 use chrono_tz::{OffsetComponents, OffsetName, TZ_VARIANTS};
 use dashmap::DashMap;
-use engine::types::QueryState;
 use lang::parse::{
     parse_command, parse_create_database, parse_create_table,
     parse_drop_database, parse_drop_table, parse_insert_into,
@@ -18,7 +17,7 @@ use meta::{
     types::{BaseChunk, BqlType, Id},
 };
 use std::{
-    env, ffi::CString, fs::remove_dir_all, lazy::SyncLazy, panic::panic_any,
+    env, fs::remove_dir_all, lazy::SyncLazy, panic::panic_any,
     path::Path, pin::Pin, sync::Mutex, time::Instant,
 };
 
@@ -85,7 +84,7 @@ pub static BMS: SyncLazy<BaseMgmtSys> = SyncLazy::new(|| {
             .takes_value(true)
     )
     .get_matches_from(args);
-    let mut conf_opt: Option<Conf> = None;
+    let mut conf_opt: Option<Conf>;
     if let Some(conf_path) = matches.value_of("conf") {
         conf_opt = Conf::load(Some(conf_path));
         if conf_opt == None {
@@ -960,8 +959,8 @@ fn command_insert_into_gen_block(
                     lc_dict_data: None,
                 },
             });
-        }
         ic += 1;
+        }
     }
     blk.ncols = blk.columns.len();
     blk.nrows = nr;

--- a/crates/runtime/src/read.rs
+++ b/crates/runtime/src/read.rs
@@ -1,16 +1,13 @@
-use dashmap::DashMap;
-use engine::{run, types::QueryState};
+use engine::types::QueryState;
 use lang::parse::{Pair, Rule};
-use libc::c_void;
 use meta::{
     store::{parts::PartStore, sys::MetaStore},
-    types::{BaseChunk, BqlType},
 };
-use std::{convert::TryFrom, ffi::CString, ptr, time::Instant};
+use std::{convert::TryFrom, time::Instant};
 
 use crate::{
-    ch::blocks::{Block, Column},
-    errs::{BaseRtError, BaseRtResult},
+    ch::blocks::Block,
+    errs::BaseRtResult,
 };
 
 pub(crate) fn query(


### PR DESCRIPTION
This mostly removed unused stuff that was generating warnings. 

The two interesting changes are in `crates/runtime/src/mgmt.rs`

Line 88 we don't need the `= None` part since the compiler can guarantee that it gets assigned the correct type in the following if statements.
```
let mut conf_opt: Option<Conf> = None;
```

Line 963 the counter got moved outside of the for-loop
```
ic += 1;
```
