### PR TITLE
Support to_date() builtin

### DIFF
--- a/arrow-datafusion/arrow/src/array/transform/mod.rs
+++ b/arrow-datafusion/arrow/src/array/transform/mod.rs
@@ -236,7 +236,10 @@ fn build_extend(array: &ArrayData) -> Extend {
         DataType::Null => null::build_extend(array),
         DataType::Boolean => boolean::build_extend(array),
         DataType::UInt8 => primitive::build_extend::<u8>(array),
-        DataType::UInt16 => primitive::build_extend::<u16>(array),
+        DataType::UInt16 
+        | DataType::Date16 => { 
+            primitive::build_extend::<u16>(array)
+        }
         DataType::UInt32 => primitive::build_extend::<u32>(array),
         DataType::UInt64 => primitive::build_extend::<u64>(array),
         DataType::Int8 => primitive::build_extend::<i8>(array),
@@ -282,7 +285,8 @@ fn build_extend_nulls(data_type: &DataType) -> ExtendNulls {
         DataType::Null => null::extend_nulls,
         DataType::Boolean => boolean::extend_nulls,
         DataType::UInt8 => primitive::extend_nulls::<u8>,
-        DataType::UInt16 => primitive::extend_nulls::<u16>,
+        DataType::UInt16 
+        | DataType::Date16 => primitive::extend_nulls::<u16>,
         DataType::UInt32 => primitive::extend_nulls::<u32>,
         DataType::UInt64 => primitive::extend_nulls::<u64>,
         DataType::Int8 => primitive::extend_nulls::<i8>,
@@ -358,6 +362,7 @@ impl<'a> MutableArrayData<'a> {
             | DataType::Int64
             | DataType::Float32
             | DataType::Float64
+            | DataType::Date16
             | DataType::Date32
             | DataType::Date64
             | DataType::Time32(_)

--- a/arrow-datafusion/arrow/src/datatypes/numeric.rs
+++ b/arrow-datafusion/arrow/src/datatypes/numeric.rs
@@ -338,6 +338,7 @@ make_numeric_type!(TimestampSecondType, i64, i64x8, m64x8);
 make_numeric_type!(TimestampMillisecondType, i64, i64x8, m64x8);
 make_numeric_type!(TimestampMicrosecondType, i64, i64x8, m64x8);
 make_numeric_type!(TimestampNanosecondType, i64, i64x8, m64x8);
+make_numeric_type!(Date16Type, u16, u16x32, m16x32);
 make_numeric_type!(Date32Type, i32, i32x16, m32x16);
 make_numeric_type!(Date64Type, i64, i64x8, m64x8);
 make_numeric_type!(Timestamp32Type, i32, i32x16, m32x16);

--- a/arrow-datafusion/arrow/src/temporal_conversions.rs
+++ b/arrow-datafusion/arrow/src/temporal_conversions.rs
@@ -28,6 +28,12 @@ const MICROSECONDS: i64 = 1_000_000;
 /// Number of nanoseconds in a second
 const NANOSECONDS: i64 = 1_000_000_000;
 
+/// converts a `u16` representing a `date16` to [`NaiveDateTime`]
+#[inline]
+pub fn date16_to_datetime(v: u16) -> NaiveDateTime {
+    NaiveDateTime::from_timestamp(v as i64 * SECONDS_IN_DAY, 0)
+}
+
 /// converts a `i32` representing a `date32` to [`NaiveDateTime`]
 #[inline]
 pub fn date32_to_datetime(v: i32) -> NaiveDateTime {

--- a/arrow-datafusion/datafusion/src/logical_plan/expr.rs
+++ b/arrow-datafusion/datafusion/src/logical_plan/expr.rs
@@ -1126,6 +1126,7 @@ unary_scalar_expr!(ToHex, to_hex);
 unary_scalar_expr!(Translate, translate);
 unary_scalar_expr!(Trim, trim);
 unary_scalar_expr!(Upper, upper);
+unary_scalar_expr!(ToDate, to_date);
 
 /// returns an array of fixed size with each argument on it.
 pub fn array(args: Vec<Expr>) -> Expr {

--- a/arrow-datafusion/datafusion/src/logical_plan/mod.rs
+++ b/arrow-datafusion/datafusion/src/logical_plan/mod.rs
@@ -40,7 +40,7 @@ pub use expr::{
     octet_length, or, regexp_match, regexp_replace, repeat, replace, reverse, right,
     round, rpad, rtrim, sha224, sha256, sha384, sha512, signum, sin, split_part, sqrt,
     starts_with, strpos, substr, sum, tan, to_hex, translate, trim, trunc, upper, when,
-    Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion,
+    Expr, ExprRewriter, ExpressionVisitor, Literal, Recursion, to_date,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/arrow-datafusion/datafusion/src/physical_plan/expressions/binary.rs
+++ b/arrow-datafusion/datafusion/src/physical_plan/expressions/binary.rs
@@ -256,6 +256,9 @@ macro_rules! binary_array_op_scalar {
             DataType::Timestamp(TimeUnit::Nanosecond, None) => {
                 compute_op_scalar!($LEFT, $RIGHT, $OP, TimestampNanosecondArray)
             }
+            DataType::Date16 => {
+                compute_op_scalar!($LEFT, $RIGHT, $OP, Date16Array)
+            }
             DataType::Date32 => {
                 compute_op_scalar!($LEFT, $RIGHT, $OP, Date32Array)
             }
@@ -287,6 +290,9 @@ macro_rules! binary_array_op {
             DataType::Utf8 => compute_utf8_op!($LEFT, $RIGHT, $OP, StringArray),
             DataType::Timestamp(TimeUnit::Nanosecond, None) => {
                 compute_op!($LEFT, $RIGHT, $OP, TimestampNanosecondArray)
+            }
+            DataType::Date16 => {
+                compute_op!($LEFT, $RIGHT, $OP, Date16Array)
             }
             DataType::Date32 => {
                 compute_op!($LEFT, $RIGHT, $OP, Date32Array)

--- a/arrow-datafusion/datafusion/src/physical_plan/expressions/coercion.rs
+++ b/arrow-datafusion/datafusion/src/physical_plan/expressions/coercion.rs
@@ -94,6 +94,8 @@ pub fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataT
 pub fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
+        (Utf8, Date16) => Some(Date16),
+        (Date16, Utf8) => Some(Date16),
         (Utf8, Date32) => Some(Date32),
         (Date32, Utf8) => Some(Date32),
         (Utf8, Date64) => Some(Date64),

--- a/arrow-datafusion/datafusion/src/physical_plan/expressions/nullif.rs
+++ b/arrow-datafusion/datafusion/src/physical_plan/expressions/nullif.rs
@@ -22,7 +22,7 @@ use crate::error::{DataFusionError, Result};
 use crate::scalar::ScalarValue;
 use arrow::array::Array;
 use arrow::array::{
-    ArrayRef, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array,
+    ArrayRef, BooleanArray, Date16Array, Date32Array, Date64Array, Float32Array, Float64Array,
     Int16Array, Int32Array, Int64Array, Int8Array, StringArray, TimestampNanosecondArray,
     UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };

--- a/arrow-datafusion/datafusion/src/physical_plan/group_scalar.rs
+++ b/arrow-datafusion/datafusion/src/physical_plan/group_scalar.rs
@@ -43,6 +43,7 @@ pub(crate) enum GroupByScalar {
     TimeMicrosecond(i64),
     TimeNanosecond(i64),
     Timestamp32(i32),
+    Date16(u16),
     Date32(i32),
 }
 
@@ -137,6 +138,7 @@ impl From<&GroupByScalar> for ScalarValue {
             GroupByScalar::Timestamp32(v) => {
                 ScalarValue::Timestamp32(Some(*v))
             }
+            GroupByScalar::Date16(v) => ScalarValue::Date16(Some(*v)),
             GroupByScalar::Date32(v) => ScalarValue::Date32(Some(*v)),
         }
     }

--- a/arrow-datafusion/datafusion/src/sql/planner.rs
+++ b/arrow-datafusion/datafusion/src/sql/planner.rs
@@ -296,7 +296,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLDataType::Float(_) => Ok(DataType::Float32),
             SQLDataType::Real | SQLDataType::Double => Ok(DataType::Float64),
             SQLDataType::Boolean => Ok(DataType::Boolean),
-            SQLDataType::Date => Ok(DataType::Date32),
+            //SQLDataType::Date => Ok(DataType::Date32),
+            SQLDataType::Date => Ok(DataType::Date16),
             SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Millisecond)),
             SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
             _ => Err(DataFusionError::NotImplemented(format!(
@@ -1495,7 +1496,8 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
         SQLDataType::Double => Ok(DataType::Float64),
         SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
-        SQLDataType::Date => Ok(DataType::Date32),
+        //SQLDataType::Date => Ok(DataType::Date32),
+        SQLDataType::Date => Ok(DataType::Date16),
         other => Err(DataFusionError::NotImplemented(format!(
             "Unsupported SQL type {:?}",
             other
@@ -1647,7 +1649,7 @@ mod tests {
             "SELECT state FROM person WHERE birth_date < CAST ('2020-01-01' as date)";
 
         let expected = "Projection: #state\
-            \n  Filter: #birth_date Lt CAST(Utf8(\"2020-01-01\") AS Date32)\
+            \n  Filter: #birth_date Lt CAST(Utf8(\"2020-01-01\") AS Date16)\
             \n    TableScan: person projection=None";
 
         quick_test(sql, expected);
@@ -2644,7 +2646,7 @@ mod tests {
     #[test]
     fn select_typedstring() {
         let sql = "SELECT date '2020-12-10' AS date FROM person";
-        let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date32) AS date\
+        let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date16) AS date\
             \n  TableScan: person projection=None";
         quick_test(sql, expected);
     }


### PR DESCRIPTION
This pull request does three things:
- Adds additional support to arrow for the new `date16` type
- Adds support for the `date16` type to DataFusion
- Adds a `to_date()` builtin to DataFusion that converts a string `to_date("YYYY-MM-DD")` to a `Date16`

Related: #84 