### PR TITLE
fix test `store::sys::unit_tests::sanity_checks`

### DIFF
--- a/crates/meta/src/store/sys.rs
+++ b/crates/meta/src/store/sys.rs
@@ -885,11 +885,9 @@ mod unit_tests {
             let cid = ms.cid_by_qname(&full_colname).unwrap();
             assert!(cid > 1);
             ms._del(&full_colname)?;
+            assert_eq!(ms.get_column_info(cid)?, None);
         }
 
-        ms._del(&full_tabname)?;
-        assert_eq!(ms.id(&full_tabname), None);
-        assert_eq!(ms.full_tabname(tid), None);
         ms._del(&full_tabname)?;
         assert_eq!(ms.id(&full_tabname), None);
         assert_eq!(ms.full_tabname(tid), None);


### PR DESCRIPTION
Signed-off-by: Frank King <frankking1729@gmail.com>

As I ran the unit tests via this command
```bash
cargo test --exclude 'arrow*' --exclude datafusion --exclude parquet --workspace -- --test-threads=1
```
Except the tests failure due to hard coded paths, I still got this error in `store::sys::unit_tests::sanity_checks`
```
---- store::sys::unit_tests::sanity_checks stdout ----
tmp_dir: /tmp
to remove the existed tmp_mdb_path: /tmp/m0 
dbid: 0
k: test_db_01.test_2020-12-21, v: [1, 0, 0, 0, 0, 0, 0, 0]
k: test_db_01.test_2020-12-21.c_as_df_gh0, v: [2, 0, 0, 0, 0, 0, 0, 0]
k: test_db_01.test_2020-12-21.c_as_df_gh1, v: [3, 0, 0, 0, 0, 0, 0, 0]
k: test_db_01.test_2020-12-21.c_as_df_gh2, v: [4, 0, 0, 0, 0, 0, 0, 0]
k: test_db_01.test_2020-12-21.c_as_df_gh3, v: [5, 0, 0, 0, 0, 0, 0, 0]
k: test_db_01.test_2020-12-21.c_as_df_gh4, v: [6, 0, 0, 0, 0, 0, 0, 0]
to iter all cols...
k: [0, 0, 0, 0, 0, 0, 0, 2, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 48], v: [0, 0, 0, 0, 0, 0, 0, 0]
k: [0, 0, 0, 0, 0, 0, 0, 3, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 49], v: [1, 0, 0, 0, 0, 0, 0, 0]
k: [0, 0, 0, 0, 0, 0, 0, 4, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 50], v: [2, 0, 0, 0, 0, 0, 0, 0]
k: [0, 0, 0, 0, 0, 0, 0, 5, 3, 0, 0, 0, 0, 0, 0, 0, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 51], v: []
k: [0, 0, 0, 0, 0, 0, 0, 5, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 51], v: [3, 0, 0, 0, 0, 0, 0, 0]
k: [0, 0, 0, 0, 0, 0, 0, 6, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 52], v: [4, 0, 0, 0, 0, 0, 0, 0]
to scan for cid=3 ...
k: [0, 0, 0, 0, 0, 0, 0, 3, 112, 107, 95, 97, 100, 115, 100, 95, 97, 100, 115, 97, 95, 49], v: [1, 0, 0, 0, 0, 0, 0, 0]
clean in reversed way...
Error: EntityDelError
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /opt/rustup/toolchains/nightly-2021-04-26-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:193:5
```

Line 890-892 in [1] seemed to be duplicated with line 893-895. I simply removed it and added a new assertion after [2] to ensure each column of the table was successfully deleted.

[1] https://github.com/tensorbase/tensorbase/blob/440480f40906b24571e1a2b20d157d542fdc9060/crates/meta/src/store/sys.rs#L890
[2] https://github.com/tensorbase/tensorbase/blob/440480f40906b24571e1a2b20d157d542fdc9060/crates/meta/src/store/sys.rs#L887