### PR TITLE
support `Decimal32` and `Decimal64` shortcut type

### DIFF
--- a/crates/meta/src/errs.rs
+++ b/crates/meta/src/errs.rs
@@ -54,8 +54,11 @@ pub enum MetaError {
     #[error("Error when converting str into BqlType enum")]
     UnknownBqlTypeConversionError,
 
-    #[error("Invalid precision or scale of decimal type")]
-    InvalidPrecisionOrScaleOfDecimalError,
+    #[error(
+        "Invalid precision [{0}] (should be in [1, 76]) \
+        or scale [{1}] (should be in [0, precision]) of decimal type"
+    )]
+    InvalidPrecisionOrScaleOfDecimalError(u8, u8),
 
     #[error("Unsupported Bql type error")]
     UnsupportedBqlTypeError,

--- a/crates/meta/src/errs.rs
+++ b/crates/meta/src/errs.rs
@@ -54,6 +54,9 @@ pub enum MetaError {
     #[error("Error when converting str into BqlType enum")]
     UnknownBqlTypeConversionError,
 
+    #[error("Invalid precision or scale of decimal type")]
+    InvalidPrecisionOrScaleOfDecimalError,
+
     #[error("Unsupported Bql type error")]
     UnsupportedBqlTypeError,
 


### PR DESCRIPTION
Signed-off-by: Frank King <frankking1729@gmail.com>

This PR added support of `Decimal32` and `Decimal64` shortcut type, and also added checks for the precision and scale of the `Decimal` type.

resolved #61