### PR TITLE
prototype of support for `FixedString` type

### DIFF
--- a/crates/base/src/strings.rs
+++ b/crates/base/src/strings.rs
@@ -196,10 +196,28 @@ pub fn bytes_to_cstring(buf: Vec<u8>) -> CString {
     unsafe { std::ffi::CString::from_vec_unchecked(buf) }
 }
 
+pub trait BytesTrim {
+    fn trim(&self) -> &Self {
+        self.trim_start().trim_end()
+    }
+    fn trim_start(&self) -> &Self;
+    fn trim_end(&self) -> &Self;
+}
+
+impl BytesTrim for [u8] {
+    fn trim_start(&self) -> &Self {
+        &self[self.iter().take_while(|b| b.is_ascii_whitespace()).count()..]
+    }
+    fn trim_end(&self) -> &Self {
+        let trimmed =
+            self.iter().rev().take_while(|b| b.is_ascii_whitespace()).count();
+        &self[..self.len() - trimmed]
+    }
+}
+
 #[cfg(test)]
 mod unit_tests {
     use std::ffi::CString;
-
 
     #[test]
     fn basic_check() {
@@ -207,6 +225,9 @@ mod unit_tests {
         super::remove_whitespace(&mut s);
         crate::debug!(&s);
         assert!(&s == "a(b)*c");
+
+        let s = " \t\rabcd\r\ne\t\n  ";
+        assert_eq!("abcd\r\ne", s.trim());
     }
 
     #[test]

--- a/crates/engine/src/datafusions.rs
+++ b/crates/engine/src/datafusions.rs
@@ -5,7 +5,7 @@ use arrow::{
         ArrayData, ArrayRef, Date16Array, DecimalArray, Float32Array,
         Float64Array, GenericStringArray, Int8Array, Int16Array, Int32Array,
         Int64Array, Timestamp32Array, UInt8Array, UInt16Array, UInt32Array,
-        UInt64Array,
+        UInt64Array, FixedSizeBinaryArray,
     },
     buffer::Buffer,
     datatypes::{DataType, Field, Schema},
@@ -50,6 +50,7 @@ fn btype_to_arrow_type(typ: BqlType) -> EngineResult<DataType> {
         BqlType::Date => Ok(DataType::Date16),
         BqlType::Decimal(p, s) => Ok(DataType::Decimal(p as usize, s as usize)),
         BqlType::String => Ok(DataType::LargeUtf8),
+        BqlType::FixedString(len) => Ok(DataType::FixedSizeBinary(len as i32)),
         BqlType::LowCardinalityString => Ok(DataType::UInt32),
         _ => Err(EngineError::UnsupportedBqlType),
     }
@@ -225,6 +226,10 @@ fn setup_tables(
                 DataType::LargeUtf8 => {
                     cols.push(Arc::new(GenericStringArray::<i64>::from(data)));
                 }
+                DataType::FixedSizeBinary(_) => {
+                    cols.push(Arc::new(FixedSizeBinaryArray::from(data)));
+
+                }
                 // DataType::Null => {}
                 // DataType::Boolean => {}
                 // DataType::Timestamp(_, _) => {}
@@ -234,7 +239,6 @@ fn setup_tables(
                 // DataType::Duration(_) => {}
                 // DataType::Interval(_) => {}
                 // DataType::Binary => {}
-                // DataType::FixedSizeBinary(_) => {}
                 // DataType::LargeBinary => {}
                 // DataType::Utf8 => {}
                 // DataType::List(_) => {}

--- a/crates/engine/src/datafusions.rs
+++ b/crates/engine/src/datafusions.rs
@@ -50,8 +50,8 @@ fn btype_to_arrow_type(typ: BqlType) -> EngineResult<DataType> {
         BqlType::Date => Ok(DataType::Date16),
         BqlType::Decimal(p, s) => Ok(DataType::Decimal(p as usize, s as usize)),
         BqlType::String => Ok(DataType::LargeUtf8),
-        BqlType::FixedString(len) => Ok(DataType::FixedSizeBinary(len as i32)),
         BqlType::LowCardinalityString => Ok(DataType::UInt32),
+        BqlType::FixedString(len) => Ok(DataType::FixedSizeBinary(len as i32)),
         _ => Err(EngineError::UnsupportedBqlType),
     }
 }

--- a/crates/lang/src/bql.pest
+++ b/crates/lang/src/bql.pest
@@ -305,7 +305,8 @@ qualified_name = ${ (name ~ ".")? ~ name }
 type_name = {
     nullable_type |
     simple_type |
-    decimal_type | 
+    decimal_type |
+    fixed_string_type |
     low_cardinality_type
 }
 simple_type = {
@@ -313,6 +314,9 @@ simple_type = {
     "Int8"  | "Int16"  | "Int32"  | "Int64"  | "Int128" | "Int256" |
     "Float32" | "Float64" | 
     "UUID" | "String" | "DateTime64" | "DateTime" | "Date"
+}
+fixed_string_type = {
+    "FixedString" ~ "(" ~ number ~ ")"
 }
 decimal_type = { 
     "Decimal" ~ "(" ~ number ~ "," ~ number ~ ")" | 

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -349,7 +349,8 @@ impl CreateTabContext {
                     // }
                     Some(p)
                         if p.as_rule() == Rule::simple_type
-                            || p.as_rule() == Rule::decimal_type =>
+                            || p.as_rule() == Rule::decimal_type
+                            || p.as_rule() == Rule::fixed_string_type =>
                     {
                         let typ = p.as_str().trim();
                         col.1.data_type = BqlType::from_str(typ)?;

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -12,7 +12,6 @@ toml = "0.5"
 num-traits = "0.2"
 itoa = "0.4"
 btoi = "0.4"
-bstr = "0.2"
 libc = "0.2"
 base = { path = "../base" }
 

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -11,6 +11,8 @@ log = "0.4"
 toml = "0.5"
 num-traits = "0.2"
 itoa = "0.4"
+btoi = "0.4"
+bstr = "0.2"
 libc = "0.2"
 base = { path = "../base" }
 

--- a/crates/meta/src/errs.rs
+++ b/crates/meta/src/errs.rs
@@ -72,6 +72,9 @@ pub enum MetaError {
     #[error("No fixed size for dynamic sized data type")]
     NoFixedSizeDataTypeError,
 
+    #[error("Too long length for FixedString")]
+    TooLongLengthForFixedStringError,
+
     #[error("Too long length for String")]
     TooLongLengthForStringError,
 

--- a/crates/meta/src/errs.rs
+++ b/crates/meta/src/errs.rs
@@ -72,9 +72,6 @@ pub enum MetaError {
     #[error("No fixed size for dynamic sized data type")]
     NoFixedSizeDataTypeError,
 
-    #[error("Too long length for FixedString")]
-    TooLongLengthForFixedStringError,
-
     #[error("Too long length for String")]
     TooLongLengthForStringError,
 

--- a/crates/meta/src/store/parts.rs
+++ b/crates/meta/src/store/parts.rs
@@ -57,7 +57,7 @@ impl CoPaInfo {
             BqlType::String => Ok(ps
                 .get_copa_siz_in_bytes_int_ptk(cid, ptk)?
                 .unwrap_or_default()),
-            _ => Ok(size * (col_typ.size()? as usize)),
+            _ => Ok(size * (col_typ.size()?)),
         }
     }
 

--- a/crates/meta/src/store/parts.rs
+++ b/crates/meta/src/store/parts.rs
@@ -57,7 +57,7 @@ impl CoPaInfo {
             BqlType::String => Ok(ps
                 .get_copa_siz_in_bytes_int_ptk(cid, ptk)?
                 .unwrap_or_default()),
-            _ => Ok(size * (col_typ.size()?)),
+            _ => Ok(size * (col_typ.size_in_usize()?)),
         }
     }
 

--- a/crates/meta/src/types.rs
+++ b/crates/meta/src/types.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use base::bytes_cat;
+use base::strings::BytesTrim;
 use num_traits::PrimInt;
 
 use crate::errs::MetaError;
@@ -218,26 +219,7 @@ impl BqlType {
     }
 
     fn _parse_num(bytes: &[u8]) -> MetaResult<u8> {
-        fn trim(bytes: &[u8]) -> &[u8] {
-            trim_end(trim_start(bytes))
-        }
-        fn trim_start(bytes: &[u8]) -> &[u8] {
-            for (i, b) in bytes.iter().enumerate() {
-                if !b.is_ascii_whitespace() {
-                    return &bytes[i..];
-                }
-            }
-            b""
-        }
-        fn trim_end(bytes: &[u8]) -> &[u8] {
-            for (i, b) in bytes.iter().enumerate().rev() {
-                if !b.is_ascii_whitespace() {
-                    return &bytes[..=i];
-                }
-            }
-            b""
-        }
-        btoi::btou(trim(bytes)).map_err(|_e| MetaError::UnknownBqlTypeConversionError)
+        btoi::btou(bytes.trim()).map_err(|_e| MetaError::UnknownBqlTypeConversionError)
     }
 
     fn _decimal_type(decimal_item: &[u8]) -> MetaResult<Self> {

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -336,7 +336,7 @@ fn write_part(
 
         //FIXME nm, om
         //write
-        let ctyp_siz = ctyp.size()?;
+        let ctyp_siz = ctyp.size_in_usize()?;
         let pt_len_in_bytes = pt_len * ctyp_siz;
         let offset_in_bytes = prid * ctyp_siz;
         //FIXME gather into bb
@@ -436,7 +436,7 @@ fn write_part_locked(
             }
             _ => {
                 let cdata = &cchk.data;
-                let ctyp_siz = ctyp.size()?;
+                let ctyp_siz = ctyp.size_in_usize()?;
                 let pt_len_in_bytes = pt_len * ctyp_siz;
                 let offset_in_bytes = prid * ctyp_siz;
                 let bb = gather_into_buf(

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -336,7 +336,7 @@ fn write_part(
 
         //FIXME nm, om
         //write
-        let ctyp_siz = ctyp.size()? as usize;
+        let ctyp_siz = ctyp.size()?;
         let pt_len_in_bytes = pt_len * ctyp_siz;
         let offset_in_bytes = prid * ctyp_siz;
         //FIXME gather into bb
@@ -436,7 +436,7 @@ fn write_part_locked(
             }
             _ => {
                 let cdata = &cchk.data;
-                let ctyp_siz = ctyp.size()? as usize;
+                let ctyp_siz = ctyp.size()?;
                 let pt_len_in_bytes = pt_len * ctyp_siz;
                 let offset_in_bytes = prid * ctyp_siz;
                 let bb = gather_into_buf(


### PR DESCRIPTION
Signed-off-by: Frank King <frankking1729@gmail.com>

Added the basic support `BqlType::FixedString`. It is able to create tables with `FixedString`-typed columns, insert into or query from such tables.

```
TensorBase :) create table test_fixed (s FixedString(10)) engine = BaseStorage;

CREATE TABLE test_fixed
(
    s FixedString(10)
)
ENGINE = BaseStorage

Ok.

0 rows in set. Elapsed: 0.014 sec. 

TensorBase :) insert into test_fixed values ('test')

INSERT INTO test_fixed VALUES

Ok.

1 rows in set. Elapsed: 0.008 sec. 
TensorBase :) select s from test_fixed

SELECT s
FROM test_fixed 

┌─s────┐
│ test │
└──────┘

1 rows in set. Elapsed: 0.019 sec. 
```

However, queries with `where` clauses such as `select col from tab where col = 'value'` is not supported due to the same reason with #98.

TODO: it might be necessary to add more tests to validate its behavior.
- [x] sanity checks

resolves #53 
