### PR TITLE
fix wrong result in truncate table

### DIFF
--- a/crates/meta/src/store/parts.rs
+++ b/crates/meta/src/store/parts.rs
@@ -384,6 +384,14 @@ impl<'a> PartStore<'a> {
         Ok(())
     }
 
+    pub fn clear(&self)->MetaResult<()>{
+        self.tree_parts.clear().map_err(|_|MetaError::EntityDelError)?;
+        self.tree_prids.clear().map_err(|_|MetaError::EntityDelError)?;
+        self.tree_part_size.clear().map_err(|_|MetaError::EntityDelError)?;
+
+        Ok(())
+    }
+
     //FIXME to rework
     //TODO
     pub fn uncache_for_table(&self, _tid: Id, _cids: &[Id]) -> MetaResult<()> {

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -606,9 +606,13 @@ impl<'a> BaseMgmtSys<'a> {
                 //remove all data
                 let dd = &self.conf.system.data_dirs;
                 for dir in dd {
-                    remove_dir_all(format!("{}/{}", dir, tid))
-                        .map_err(|e| BaseRtError::WrappingIoError(e))?;
-                    log::debug!("Data of table {}, removed", &tn);
+                    let res = remove_dir_all(format!("{}/{}", dir, tid));
+                    if let Err(e) = res {
+                        if e.kind() != std::io::ErrorKind::NotFound {
+                            return Err(BaseRtError::WrappingIoError(e));
+                        }
+                    }
+                    log::debug!("Data of table {}, truncated", &tn);
                 }
                 let cids = ms.get_column_ids(qtn.as_str())?;
                 //uncache part files

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -615,6 +615,9 @@ impl<'a> BaseMgmtSys<'a> {
                 //FIXME need more tests in that no lock here
                 let ps = &self.part_store;
                 ps.uncache_for_table(tid, &cids)?;
+
+                ps.clear()?;
+
                 Ok(BaseCommandKind::Drop)
             }
             None if fallible => {

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -27,6 +27,7 @@ async fn tests_integ_stress_test_ddl() -> errors::Result<()> {
         conn.execute(format!("DROP TABLE IF EXISTS {}", tn)).await?;
         conn.execute(format!("CREATE TABLE {}(x Int64)", tn))
             .await?;
+        conn.execute(format!("TRUNCATE TABLE {}", tn)).await?;
     }
 
     conn.execute("drop database if exists test_db").await?;


### PR DESCRIPTION
`truncate table` doesn't change the `PartStore` metadata. So if we `truncate table` and `insert into table`, we will get the wrong result.
This PR makes it right.