### PR TITLE
Fix some typos and clippy lints

### DIFF
--- a/arrow-datafusion/ballista/rust/scheduler/src/planner.rs
+++ b/arrow-datafusion/ballista/rust/scheduler/src/planner.rs
@@ -80,7 +80,7 @@ impl DistributedPlanner {
 
     /// Returns a potentially modified version of the input execution_plan along with the resulting query stages.
     /// This function is needed because the input execution_plan might need to be modified, but it might not hold a
-    /// compelte query stage (its parent might also belong to the same stage)
+    /// complete query stage (its parent might also belong to the same stage)
     fn plan_query_stages_internal(
         &mut self,
         job_id: &str,

--- a/arrow-datafusion/ballista/rust/scheduler/src/state/mod.rs
+++ b/arrow-datafusion/ballista/rust/scheduler/src/state/mod.rs
@@ -578,7 +578,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn job_metadata_non_existant() -> Result<(), BallistaError> {
+    async fn job_metadata_non_existent() -> Result<(), BallistaError> {
         let state = SchedulerState::new(
             Arc::new(StandaloneClient::try_new_temporary()?),
             "test".to_string(),
@@ -619,7 +619,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn task_status_non_existant() -> Result<(), BallistaError> {
+    async fn task_status_non_existent() -> Result<(), BallistaError> {
         let state = SchedulerState::new(
             Arc::new(StandaloneClient::try_new_temporary()?),
             "test".to_string(),

--- a/crates/base/proc_macro/src/lib.rs
+++ b/crates/base/proc_macro/src/lib.rs
@@ -74,7 +74,7 @@ fn expand_str_raw(src: &str) -> TokenStream {
                 );
             }
         }
-        if ss.len() != 0 {
+        if !ss.is_empty() {
             count_chars += ss.len();
             ret.push(quote! {  #ss.put_into_string(&mut buf); });
         }
@@ -148,7 +148,7 @@ fn expand_cstr_raw(src: &str) -> TokenStream {
                 );
             }
         }
-        if ss.len() != 0 {
+        if !ss.is_empty() {
             count_chars += ss.len();
             ret.push(quote! {  #ss.put_into_bytes(&mut buf); });
         }
@@ -180,7 +180,7 @@ pub fn async_test(
         "#[async_test] attribute has no parameter"
     );
     let ts: TokenStream = ts.into();
-    let mut afn: syn::ItemFn = syn::parse2(ts.clone()).expect(
+    let mut afn: syn::ItemFn = syn::parse2(ts).expect(
         "function expected",
     );
 

--- a/crates/base/src/mem.rs
+++ b/crates/base/src/mem.rs
@@ -37,7 +37,7 @@ impl<T> SyncPointer<T> {
     }
 }
 
-/// WARN it is your responsiblity to ensure this transmuting is safe
+/// WARN it is your responsibility to ensure this transmuting is safe
 #[inline]
 pub fn shape_slice<T>(slice: &[u8]) -> &[T] {
     unsafe {
@@ -48,7 +48,7 @@ pub fn shape_slice<T>(slice: &[u8]) -> &[T] {
     }
 }
 
-/// WARN it is your responsiblity to ensure this transmuting is safe
+/// WARN it is your responsibility to ensure this transmuting is safe
 #[inline]
 pub fn shape_vec<T>(v: Vec<u8>) -> Vec<T> {
     let (ptr, len, cap) = v.into_raw_parts();
@@ -62,7 +62,7 @@ pub fn shape_vec<T>(v: Vec<u8>) -> Vec<T> {
 }
 
 
-/// WARN it is your responsiblity to ensure this transmuting is safe
+/// WARN it is your responsibility to ensure this transmuting is safe
 #[inline]
 pub fn shape_vec_u8<T>(v: Vec<T>) -> Vec<u8> {
     let (ptr, len, cap) = v.into_raw_parts();

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -23,7 +23,7 @@ pub struct BqlParser;
 pub fn pretty_parse_tree(pairs: Pairs<Rule>) -> String {
     let lines: Vec<_> = pairs.map(|pair| format_pair(pair, 0, true)).collect();
     let lines = lines.join("\n");
-    return format!("{}", lines);
+    return lines.to_string();
 }
 
 fn format_pair(

--- a/crates/lightjit/src/builtins.rs
+++ b/crates/lightjit/src/builtins.rs
@@ -31,7 +31,7 @@ pub fn toYYYYMMDD(ut: u64) -> u64 {
     ymd.y as u64 * 10000 + ymd.m as u64 * 100 + ymd.d as u64
 }
 
-pub fn rem(dd: u64, ds: u64) -> u64 {
+pub const fn rem(dd: u64, ds: u64) -> u64 {
     dd % ds
 }
 

--- a/crates/lightjit/src/jit.rs
+++ b/crates/lightjit/src/jit.rs
@@ -55,7 +55,7 @@ impl JIT {
     pub fn compile(&mut self, input: &str) -> Result<*const u8, String> {
         // First, parse the string, producing AST nodes.
         let (name, params, the_return, stmts) =
-            parser::function(&input).map_err(|e| e.to_string())?;
+            parser::function(input).map_err(|e| e.to_string())?;
 
         // Then, translate the AST nodes into Cranelift IR.
         self.translate(params, the_return, stmts)?;
@@ -485,19 +485,19 @@ fn declare_variables_in_stmt(
         Expr::IfElse(ref _condition, ref then_body, ref else_body) => {
             for stmt in then_body {
                 declare_variables_in_stmt(
-                    int, builder, variables, index, &stmt,
+                    int, builder, variables, index, stmt,
                 );
             }
             for stmt in else_body {
                 declare_variables_in_stmt(
-                    int, builder, variables, index, &stmt,
+                    int, builder, variables, index, stmt,
                 );
             }
         }
         Expr::WhileLoop(ref _condition, ref loop_body) => {
             for stmt in loop_body {
                 declare_variables_in_stmt(
-                    int, builder, variables, index, &stmt,
+                    int, builder, variables, index, stmt,
                 );
             }
         }

--- a/crates/meta/src/store/parts.rs
+++ b/crates/meta/src/store/parts.rs
@@ -149,8 +149,8 @@ impl<'a> PartStore<'a> {
         meta_dirs: &[T],
         data_dirs: &'a Vec<String>,
     ) -> MetaResult<Self> {
-        assert!(meta_dirs.len() > 0);
-        assert!(data_dirs.len() > 0);
+        assert!(!meta_dirs.is_empty());
+        assert!(!data_dirs.is_empty());
 
         let p0 = [meta_dirs[0].as_ref(), "p0"].join("/");
         let mdb = sled::Config::default()

--- a/crates/meta/src/store/sys.rs
+++ b/crates/meta/src/store/sys.rs
@@ -78,7 +78,7 @@ const KEY_SYS_IDX_TABS: &'static str = "system.__idx_tabs_";
  */
 impl MetaStore {
     pub fn new<T: AsRef<str>>(dirs: &[T]) -> MetaResult<Self> {
-        assert!(dirs.len() > 0);
+        assert!(!dirs.is_empty());
 
         let p0 = [dirs[0].as_ref(), "m0"].join("/");
         let mdb = sled::Config::default()
@@ -672,10 +672,10 @@ impl MetaStore {
         let dn = &tab.dbname;
         if let Some(_) = self.id(&dn) {
             let tn = &tab.name;
-            let tid = self.new_tab(&dn, &tn)?;
+            let tid = self.new_tab(dn, tn)?;
             self.new_table_info(tid, &tab.tab_info)?;
             for (colname, col_info) in &tab.columns {
-                let cid = self.new_col(&dn, &tn, &colname)?;
+                let cid = self.new_col(dn, tn, colname)?;
                 let r = self
                     .tree_cols
                     .insert(&cid.to_be_bytes(), col_info.as_bytes())

--- a/crates/runtime/src/ch/messages.rs
+++ b/crates/runtime/src/ch/messages.rs
@@ -67,7 +67,7 @@ pub fn response_to(
             rb.ensure_enough_bytes_to_read(38)?;
             if is_eodp(rb, cctx.is_compressed) {
                 // rb0.advance(rb.len()); //consume for rb
-                log::debug!("all data packet recieved");
+                log::debug!("all data packet received");
                 //FIXME clear the asistant rb for next data??? data packet pipelining
                 // rb0.clear();
                 //EoS

--- a/crates/tests_integ/ch_client/src/client.rs
+++ b/crates/tests_integ/ch_client/src/client.rs
@@ -66,7 +66,7 @@ pub(super) struct Inner {
     pub(crate) info: ServerInfo,
 }
 
-pub(super) type InnerConection = Inner;
+pub(super) type InnerConnection = Inner;
 
 pub struct QueryResult<'a, R: AsyncRead> {
     pub(crate) inner: ResponseStream<'a, R>,

--- a/crates/tests_integ/ch_client/src/errors.rs
+++ b/crates/tests_integ/ch_client/src/errors.rs
@@ -125,7 +125,7 @@ pub enum Error {
     Url(#[source] UrlError),
 
     #[error("Deserialize error: `{}`", _0)]
-    Convertion(ConversionError),
+    Conversion(ConversionError),
 
     #[error("Other error: `{}`", _0)]
     Other(Cow<'static, str>),
@@ -186,7 +186,7 @@ impl From<ParseError> for Error {
 
 impl From<Utf8Error> for Error {
     fn from(_err: Utf8Error) -> Self {
-        Error::Convertion(ConversionError::Utf8)
+        Error::Conversion(ConversionError::Utf8)
     }
 }
 
@@ -210,7 +210,7 @@ impl From<UrlError> for Error {
 
 impl From<ConversionError> for Error {
     fn from(err: ConversionError) -> Self {
-        Error::Convertion(err)
+        Error::Conversion(err)
     }
 }
 

--- a/crates/tests_integ/ch_client/src/pool/builder.rs
+++ b/crates/tests_integ/ch_client/src/pool/builder.rs
@@ -7,7 +7,7 @@ use std::{
 use tokio::sync;
 
 use crate::{
-    client::InnerConection,
+    client::InnerConnection,
     errors::{Result, UrlError},
     sync::WakerSet,
 };
@@ -143,7 +143,7 @@ impl PoolBuilder {
 
         #[allow(unused_variables)]
         if cfg!(feature = "recycle") {
-            let (tx, rx) = sync::mpsc::unbounded_channel::<Option<Box<InnerConection>>>();
+            let (tx, rx) = sync::mpsc::unbounded_channel::<Option<Box<InnerConnection>>>();
         }
 
         let hosts = options.take_addr();

--- a/crates/tests_integ/ch_client/src/pool/recycler.rs
+++ b/crates/tests_integ/ch_client/src/pool/recycler.rs
@@ -8,10 +8,10 @@ use std::{
 use futures::stream::Stream;
 use tokio::sync::mpsc;
 
-use super::{Inner, InnerConection, POOL_STATUS_STOPPED};
+use super::{Inner, InnerConnection, POOL_STATUS_STOPPED};
 
 pub(crate) struct Recycler {
-    dropped: mpsc::UnboundedReceiver<Option<Box<InnerConection>>>,
+    dropped: mpsc::UnboundedReceiver<Option<Box<InnerConnection>>>,
     inner: Arc<Inner>,
     eof: bool,
 }
@@ -19,7 +19,7 @@ pub(crate) struct Recycler {
 impl Recycler {
     pub(crate) fn new(
         inner: Arc<Inner>,
-        dropped: mpsc::UnboundedReceiver<Option<Box<InnerConection>>>,
+        dropped: mpsc::UnboundedReceiver<Option<Box<InnerConnection>>>,
     ) -> Recycler {
         Recycler {
             inner,

--- a/crates/tests_integ/ch_client/src/protocol/block.rs
+++ b/crates/tests_integ/ch_client/src/protocol/block.rs
@@ -87,7 +87,7 @@ impl std::fmt::Debug for BlockInfo {
 
 impl BlockInfo {
     /// Clickhouse empty block is used as a marker of end of data transfer
-    pub(super) fn is_empty(&self) -> bool {
+    pub(super) const fn is_empty(&self) -> bool {
         self.rows == 0 && self.cols == 0
     }
 }

--- a/crates/tests_integ/ch_client/src/protocol/column.rs
+++ b/crates/tests_integ/ch_client/src/protocol/column.rs
@@ -460,7 +460,7 @@ impl<T: Ord + Copy> EnumIndex<T> {
     /// Sort by enum name
     #[inline]
     pub(crate) fn fn_sort_str(item1: &EnumIndex<T>, item2: &EnumIndex<T>) -> Ordering {
-        Ord::cmp(item1.1.as_ref(), &item2.1.as_ref())
+        Ord::cmp(item1.1.as_ref(), item2.1.as_ref())
     }
 }
 

--- a/crates/tests_integ/ch_client/src/types/mod.rs
+++ b/crates/tests_integ/ch_client/src/types/mod.rs
@@ -109,15 +109,15 @@ impl Field {
     }
 
     #[inline]
-    pub fn is_nullable(&self) -> bool {
+    pub const fn is_nullable(&self) -> bool {
         (self.flag & FIELD_NULLABLE) == FIELD_NULLABLE
     }
     #[inline]
-    pub fn is_array(&self) -> bool {
+    pub const fn is_array(&self) -> bool {
         (self.flag & FIELD_ARRAY) == FIELD_ARRAY
     }
     #[inline]
-    pub fn is_lowcardinality(&self) -> bool {
+    pub const fn is_lowcardinality(&self) -> bool {
         (self.flag & FIELD_LOWCARDINALITY) == FIELD_LOWCARDINALITY
     }
 


### PR DESCRIPTION
Fix some typos and clippy lints like:

```
warning: this could be a `const fn`
   --> crates/tests_integ/ch_client/src/types/mod.rs:112:5
    |
112 | /     pub fn is_nullable(&self) -> bool {
113 | |         (self.flag & FIELD_NULLABLE) == FIELD_NULLABLE
114 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn

warning: this expression borrows a reference (`&std::string::String`) that is immediately dereferenced by the compiler
   --> crates/meta/src/store/sys.rs:678:50
    |
678 |                 let cid = self.new_col(&dn, &tn, &colname)?;
    |                                                  ^^^^^^^^ help: change this to: `colname`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```