### PR TITLE
basic support of default timezone

### DIFF
--- a/.github/workflows/base_integ_sanity_checks.yml
+++ b/.github/workflows/base_integ_sanity_checks.yml
@@ -35,6 +35,7 @@ jobs:
             [server]                           
             ip_addr = "localhost"              
             port = 9528   
+            timezone = "Etc/GMT-8"
     - name: TensorBase wait for server up 01
       run: cargo install wait-for-them
     - name: TensorBase wait for server up 02

--- a/crates/arrow/Cargo.toml
+++ b/crates/arrow/Cargo.toml
@@ -47,11 +47,13 @@ regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3.5", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
+chrono-tz = "0.5"
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
 multiversion = "0.6.1"
+base = { path = "../base" }
 
 [features]
 default = ["csv", "ipc"]

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -15,7 +15,9 @@ chrono = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"
 crc32c = "0.6"
+chrono-tz = "0.5"
+serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-# chrono = "0.4"

--- a/crates/base/src/datetimes.rs
+++ b/crates/base/src/datetimes.rs
@@ -5,7 +5,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::errs::{BaseError, BaseResult};
 
-use std::{fmt, lazy::SyncLazy, str::FromStr};
+use std::{fmt, str::FromStr};
 
 #[derive(Debug, Default)]
 pub struct YMD {
@@ -34,8 +34,6 @@ pub struct BaseTimeZone {
     /// Offset of the time zone in seconds.
     offset: i32,
 }
-
-static UTC: SyncLazy<BaseTimeZone> = SyncLazy::new(|| BaseTimeZone::default());
 
 impl FromStr for BaseTimeZone {
     type Err = BaseError;
@@ -96,17 +94,12 @@ impl BaseTimeZone {
 }
 
 #[inline(always)]
-pub fn ymdhms_to_unixtime_utc(dt: YMDHMS) -> u32 {
-    ymdhms_to_unixtime(dt, &UTC)
-}
-
-#[inline(always)]
-pub fn ymdhms_to_unixtime(dt: YMDHMS, tz: &BaseTimeZone) -> u32 {
+pub fn ymdhms_to_unixtime(dt: YMDHMS, tz_offset: i32) -> u32 {
     sub_tz_offset(
         NaiveDate::from_ymd(dt.0 as i32, dt.1 as u32, dt.2 as u32)
             .and_hms(dt.3 as u32, dt.4 as u32, dt.5 as u32)
             .timestamp() as i32,
-        tz,
+        tz_offset,
     ) as u32
 }
 
@@ -116,47 +109,32 @@ pub fn div_mod_floor<T: Integer>(x: T, y: T) -> (T, T) {
 }
 
 #[inline(always)]
-fn add_tz_offset(unixtime: i32, tz: &BaseTimeZone) -> i32 {
-    let offset = tz.offset();
+fn add_tz_offset(unixtime: i32, tz_offset: i32) -> i32 {
+    let offset = tz_offset;
     unixtime + offset
 }
 
 #[inline(always)]
-fn sub_tz_offset(unixtime: i32, tz: &BaseTimeZone) -> i32 {
-    let offset = tz.offset();
+fn sub_tz_offset(unixtime: i32, tz_offset: i32) -> i32 {
+    let offset = tz_offset;
     unixtime - offset
 }
 
 #[inline(always)]
-pub fn unixtime_to_days_utc(unixtime: i32) -> i64 {
-    unixtime_to_days(unixtime, &UTC)
-}
-
-#[inline(always)]
-pub fn unixtime_to_days(unixtime: i32, tz: &BaseTimeZone) -> i64 {
-    let unixtime = add_tz_offset(unixtime, tz);
+pub fn unixtime_to_days(unixtime: i32, tz_offset: i32) -> i64 {
+    let unixtime = add_tz_offset(unixtime, tz_offset);
     let (days, _) = div_mod_floor(unixtime as i64, 86_400);
     days
 }
 
 #[inline(always)]
-pub fn unixtime_to_ymd_utc(unixtime: i32) -> YMD {
-    unixtime_to_ymd(unixtime, &UTC)
+pub fn unixtime_to_ymd(unixtime: i32, tz_offset: i32) -> YMD {
+    days_to_ymd(unixtime_to_days(unixtime, tz_offset) as i32)
 }
 
 #[inline(always)]
-pub fn unixtime_to_ymd(unixtime: i32, tz: &BaseTimeZone) -> YMD {
-    days_to_ymd(unixtime_to_days(unixtime, tz) as i32)
-}
-
-#[inline(always)]
-pub fn unixtime_to_hms_utc(unixtime: i32) -> HMS {
-    unixtime_to_hms(unixtime, &UTC)
-}
-
-#[inline(always)]
-pub fn unixtime_to_hms(unixtime: i32, tz: &BaseTimeZone) -> HMS {
-    let unixtime = add_tz_offset(unixtime, tz);
+pub fn unixtime_to_hms(unixtime: i32, tz_offset: i32) -> HMS {
+    let unixtime = add_tz_offset(unixtime, tz_offset);
     let (_, seconds) = div_mod_floor(unixtime, 86_400);
     let (hours, seconds) = div_mod_floor(seconds, 3_600);
     let (minutes, seconds) = div_mod_floor(seconds, 60);
@@ -171,35 +149,20 @@ pub fn unixtime_to_second(unixtime: i32) -> u8 {
 }
 
 #[inline(always)]
-pub fn unixtime_to_year_utc(unixtime: i32) -> u16 {
-    unixtime_to_year(unixtime, &UTC)
-}
-
-#[inline(always)]
-pub fn unixtime_to_year(unixtime: i32, tz: &BaseTimeZone) -> u16 {
-    let unixtime = add_tz_offset(unixtime, tz);
+pub fn unixtime_to_year(unixtime: i32, tz_offset: i32) -> u16 {
+    let unixtime = add_tz_offset(unixtime, tz_offset);
     let (days, _) = div_mod_floor(unixtime as i64, 86_400);
     days_to_year(days as i32)
 }
 
 #[inline(always)]
-pub fn unixtime_to_ordinal_utc(unixtime: i32) -> u16 {
-    unixtime_to_ordinal(unixtime, &UTC)
+pub fn unixtime_to_ordinal(unixtime: i32, tz_offset: i32) -> u16 {
+    days_to_ordinal(unixtime_to_days(unixtime, tz_offset) as i32)
 }
 
 #[inline(always)]
-pub fn unixtime_to_ordinal(unixtime: i32, tz: &BaseTimeZone) -> u16 {
-    days_to_ordinal(unixtime_to_days(unixtime, tz) as i32)
-}
-
-#[inline(always)]
-pub fn unixtime_to_weekday_utc(unixtime: i32) -> u8 {
-    unixtime_to_weekday(unixtime, &UTC)
-}
-
-#[inline(always)]
-pub fn unixtime_to_weekday(unixtime: i32, tz: &BaseTimeZone) -> u8 {
-    days_to_weekday(unixtime_to_days(unixtime, tz) as i32)
+pub fn unixtime_to_weekday(unixtime: i32, tz_offset: i32) -> u8 {
+    days_to_weekday(unixtime_to_days(unixtime, tz_offset) as i32)
 }
 
 #[inline(always)]
@@ -255,11 +218,7 @@ fn two_digits(b1: u8, b2: u8) -> Result<u64, BaseError> {
     Ok(((b1 - b'0') * 10 + (b2 - b'0')) as u64)
 }
 
-pub fn parse_to_epoch(s: &str) -> BaseResult<u32> {
-    parse_to_epoch_tz(s, None)
-}
-
-pub fn parse_to_epoch_tz(s: &str, tz: Option<&BaseTimeZone>) -> BaseResult<u32> {
+pub fn parse_to_epoch(s: &str, tz_offset: i32) -> BaseResult<u32> {
     if s.len() < "2018-02-14T00:28:07".len() {
         return Err(BaseError::InvalidDatetimeFormat);
     }
@@ -293,7 +252,7 @@ pub fn parse_to_epoch_tz(s: &str, tz: Option<&BaseTimeZone>) -> BaseResult<u32> 
             minute as u8,
             second as u8,
         ),
-        tz.unwrap_or(&UTC),
+        tz_offset,
     ))
 }
 
@@ -309,23 +268,24 @@ mod unit_tests {
     #[test]
     fn basic_check() -> BaseResult<()> {
         show_option_size!(YMDHMS);
+        let tz_offset = 0;
 
-        let ut = ymdhms_to_unixtime_utc(YMDHMS(1970, 1, 1, 0, 0, 0));
+        let ut = ymdhms_to_unixtime(YMDHMS(1970, 1, 1, 0, 0, 0), tz_offset);
         println!("unixtime: {}", ut);
         assert_eq!(ut, 0);
 
-        let ut = ymdhms_to_unixtime_utc(YMDHMS(2004, 9, 17, 0, 0, 0));
+        let ut = ymdhms_to_unixtime(YMDHMS(2004, 9, 17, 0, 0, 0), tz_offset);
         println!("unixtime: {}", ut);
         assert_eq!(ut, 1095379200);
 
         // 1356388352
         // 1354291200
-        let ymd = unixtime_to_ymd_utc(1354291200);
+        let ymd = unixtime_to_ymd(1354291200, tz_offset);
         println!("1356388352 to ymd: {:?}", ymd);
 
         let s = "2018-02-14 00:28:07";
-        let ut0 = parse_to_epoch("2018-02-14T00:28:07").unwrap();
-        let ut1 = parse_to_epoch(s).unwrap();
+        let ut0 = parse_to_epoch("2018-02-14T00:28:07", tz_offset).unwrap();
+        let ut1 = parse_to_epoch(s, tz_offset).unwrap();
         println!("ut: {:?}", ut);
         assert_eq!(ut0, ut1);
         let dt = NaiveDateTime::from_timestamp(ut0 as i64, 0);
@@ -381,18 +341,20 @@ mod unit_tests {
 
     #[test]
     fn test_unixtime_to_year() {
+        let tz_offset = 8 * 3600;
         for epoch in (1..1000_000_000).step_by(1000) {
-            let ymd = unixtime_to_ymd_utc(epoch);
-            let y = unixtime_to_year_utc(epoch);
+            let ymd = unixtime_to_ymd(epoch, tz_offset);
+            let y = unixtime_to_year(epoch, tz_offset);
             assert_eq!(y, ymd.y);
         }
     }
 
     #[test]
     fn test_unixtime_to_ordinal() {
+        let tz_offset = 8 * 3600;
         for epoch in (1..1000_000_000).step_by(1000) {
-            let year = unixtime_to_year_utc(epoch);
-            let ordinal = unixtime_to_ordinal_utc(epoch);
+            let year = unixtime_to_year(epoch, tz_offset);
+            let ordinal = unixtime_to_ordinal(epoch, tz_offset);
             let date = NaiveDate::from_yo(year as i32, ordinal as u32);
             assert_eq!(year, date.year() as u16);
             assert_eq!(ordinal, date.ordinal() as u16);
@@ -401,9 +363,10 @@ mod unit_tests {
 
     #[test]
     fn test_unixtime_to_weekday() {
+        let tz_offset = 8 * 3600;
         for epoch in (1..1000_000_000).step_by(1000) {
-            let weekday = unixtime_to_weekday_utc(epoch);
-            let ymd = unixtime_to_ymd_utc(epoch);
+            let weekday = unixtime_to_weekday(epoch, tz_offset);
+            let ymd = unixtime_to_ymd(epoch, tz_offset);
             let date = NaiveDate::from_ymd(ymd.y as i32, ymd.m as u32, ymd.d as u32);
             assert_eq!(weekday, date.weekday().number_from_monday() as u8);
         }
@@ -411,18 +374,15 @@ mod unit_tests {
 
     #[test]
     fn test_unixtime_to_hms() {
+        let tz_offset = 8 * 3600;
         for epoch in 0..86_400 * 10 {
-            let ymd = unixtime_to_ymd_utc(epoch as i32);
-            let hms = unixtime_to_hms_utc(epoch as i32);
+            let ymd = unixtime_to_ymd(epoch as i32, tz_offset);
+            let hms = unixtime_to_hms(epoch as i32, tz_offset);
             let seconds = unixtime_to_second(epoch as i32);
-            let converted_epoch = ymdhms_to_unixtime_utc(YMDHMS(
-                ymd.y as i16,
-                ymd.m,
-                ymd.d,
-                hms.h,
-                hms.m,
-                hms.s,
-            ));
+            let converted_epoch = ymdhms_to_unixtime(
+                YMDHMS(ymd.y as i16, ymd.m, ymd.d, hms.h, hms.m, hms.s),
+                tz_offset,
+            );
             assert_eq!(epoch, converted_epoch);
             assert_eq!(hms.s, seconds);
         }
@@ -432,12 +392,12 @@ mod unit_tests {
     fn test_timezones() {
         let timezones: Vec<_> = TZ_VARIANTS
             .iter()
-            .map(|tz| BaseTimeZone::from_str(tz.name()).unwrap())
+            .map(|btz| BaseTimeZone::from_str(btz.name()).unwrap())
             .collect();
         let time = "2021-07-03 15:03:28";
         let epoch = 1625324608;
         for tz in timezones {
-            let epoch_with_tz = parse_to_epoch_tz(&time, Some(&tz)).unwrap() as i32;
+            let epoch_with_tz = parse_to_epoch(&time, tz.offset()).unwrap() as i32;
             println!(
                 "epoch_with_tz - epoch = {}, offset = {}",
                 epoch_with_tz - epoch,

--- a/crates/base/src/errs.rs
+++ b/crates/base/src/errs.rs
@@ -32,6 +32,9 @@ pub enum BaseError {
     #[error("Invalid datetime digit")]
     InvalidDatetimeDigit,
 
+    #[error("Invalid time zone {0}")]
+    InvalidTimeZone(String),
+
     #[error("Failed to mmap")]
     FailedToMmap,
 

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -20,7 +20,8 @@
     specialization,
     llvm_asm,
     vec_into_raw_parts,
-    core_intrinsics
+    core_intrinsics,
+    once_cell
 )]
 pub mod codec;
 pub mod datetimes;

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -24,6 +24,7 @@
     clippy::type_complexity,
     clippy::upper_case_acronyms
 )]
+#![feature(once_cell)]
 
 //! [DataFusion](https://github.com/apache/arrow-datafusion)
 //! is an extensible query execution framework that uses

--- a/crates/datafusion/src/physical_plan/clickhouse.rs
+++ b/crates/datafusion/src/physical_plan/clickhouse.rs
@@ -2,27 +2,28 @@
 //!
 //! Tests are located at `datafusion_tests`.
 
-use super::{
-    ColumnarValue, PhysicalExpr,
-};
+use super::{ColumnarValue, PhysicalExpr};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::datetime_expressions;
 use crate::physical_plan::functions::Signature;
-use crate::{
-    error::{DataFusionError, Result},
-};
 use arrow::{
     array::{
-        Date16Array, Timestamp32Array, UInt16Array, UInt8Array, 
-        BooleanArray, ArrayRef, GenericStringArray, StringOffsetSizeTrait, Array,
+        ArrayRef, BooleanArray, Date16Array, GenericStringArray, PrimitiveArray,
+        StringOffsetSizeTrait, Timestamp32Array, UInt16Array, UInt8Array,
     },
-    datatypes::DataType,
+    datatypes::{ArrowPrimitiveType, DataType},
 };
 use fmt::{Debug, Formatter};
-use std::{fmt, str::FromStr, sync::Arc};
-use std::any::type_name;
-use log::debug;
+use std::{any::type_name, fmt, lazy::SyncOnceCell, str::FromStr, sync::Arc};
 
-use base::datetimes::{days_to_year, days_to_ymd, unixtime_to_year, unixtime_to_ymd, unixtime_to_hms, unixtime_to_second, days_to_ordinal, days_to_weekday, unixtime_to_ordinal, unixtime_to_weekday};
+use base::datetimes::{
+    days_to_ordinal, days_to_weekday, days_to_year, days_to_ymd, unixtime_to_hms,
+    unixtime_to_ordinal, unixtime_to_second, unixtime_to_weekday, unixtime_to_year,
+    unixtime_to_ymd, BaseTimeZone,
+};
+
+/// The default timezone is specified at the server's startup stage.
+pub static DEFAULT_TIMEZONE: SyncOnceCell<BaseTimeZone> = SyncOnceCell::new();
 
 /// Enum of clickhouse built-in scalar functions
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,6 +75,7 @@ impl FromStr for BuiltinScalarFunction {
             "toMinute" => BuiltinScalarFunction::ToMinute,
             "toSecond" => BuiltinScalarFunction::ToSecond,
             "endsWith" => BuiltinScalarFunction::EndsWith,
+
             _ => {
                 return Err(DataFusionError::Plan(format!(
                     "There is no built-in clickhouse function named {}",
@@ -111,7 +113,7 @@ impl BuiltinScalarFunction {
     /// Returns the implementation of the scalar function
     pub fn func_impl(
         &self,
-        _args: &[Arc<dyn PhysicalExpr>]
+        _args: &[Arc<dyn PhysicalExpr>],
     ) -> fn(&[ColumnarValue]) -> Result<ColumnarValue> {
         match self {
             BuiltinScalarFunction::ToYear => expr_to_year,
@@ -142,115 +144,169 @@ impl BuiltinScalarFunction {
             BuiltinScalarFunction::ToDate => Signature::Uniform(1, vec![DataType::Utf8]),
             BuiltinScalarFunction::ToHour
             | BuiltinScalarFunction::ToMinute
-            | BuiltinScalarFunction::ToSecond => Signature::Uniform(1, vec![DataType::Timestamp32(None)]),
+            | BuiltinScalarFunction::ToSecond => {
+                Signature::Uniform(1, vec![DataType::Timestamp32(None)])
+            }
             BuiltinScalarFunction::EndsWith => Signature::Any(2),
         }
     }
 }
 
-/// Extracts the years from Date16 array
-pub fn date16_to_year(array: &Date16Array) -> Result<UInt16Array> {
-    Ok(array.iter().map(|x| Some(days_to_year(x? as i32))).collect())
+fn handle_date_fn<T, U, F>(array: &PrimitiveArray<T>, f: F) -> Result<PrimitiveArray<U>>
+where
+    T: ArrowPrimitiveType,
+    U: ArrowPrimitiveType,
+    F: Fn(Option<T::Native>) -> Option<U::Native>,
+{
+    Ok(array.iter().map(f).collect())
 }
 
-/// Extracts the months from Date16 array
-pub fn date16_to_month(array: &Date16Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(days_to_ymd(x? as i32).m)).collect())
+fn handle_timestamp_fn<T, U, F>(
+    array: &PrimitiveArray<T>,
+    tz: &Option<BaseTimeZone>,
+    f: F,
+) -> Result<PrimitiveArray<U>>
+where
+    T: ArrowPrimitiveType,
+    U: ArrowPrimitiveType,
+    F: Fn(Option<T::Native>, &BaseTimeZone) -> Option<U::Native>,
+{
+    let tz = tz
+        .as_ref()
+        .or(DEFAULT_TIMEZONE.get())
+        .ok_or(DataFusionError::Internal(
+            "default time zone not initialized".to_string(),
+        ))?;
+    Ok(array.iter().map(|x| f(x, tz)).collect())
 }
 
-/// Extracts the days of year from Date16 array
-pub fn date16_to_day_of_year(array: &Date16Array) -> Result<UInt16Array> {
-    Ok(array.iter().map(|x| Some(days_to_ordinal(x? as i32))).collect())
+macro_rules! def_datetime_fn {
+    ( $(
+        $(#[$OUTER:meta])*
+        fn $OP:ident($ARRAY:ident: $INPUT_TY:ty $(, $TZ:ident )? ) -> $OUTPUT_TY:ty {
+            $EXPR:expr
+        }
+    )* ) => { $( def_datetime_fn!{
+        @wrapped $(#[$OUTER])*
+        fn $OP($ARRAY: $INPUT_TY $(, $TZ )? ) -> $OUTPUT_TY {
+            $EXPR
+        }
+    } )* };
+    // wrapped rule for define date functions
+    (
+        @wrapped $(#[$OUTER:meta])*
+        fn $OP:ident($ARRAY:ident: $INPUT_TY:ty ) -> $OUTPUT_TY:ty {
+            $EXPR:expr
+        }
+    ) => {
+        $(#[$OUTER])* pub fn $OP($ARRAY: $INPUT_TY ) -> $OUTPUT_TY {
+            handle_date_fn($ARRAY, $EXPR)
+        }
+    };
+    // wrapped rule for define timestamp functions
+    (
+        @wrapped $(#[$OUTER:meta])*
+        fn $OP:ident($ARRAY:ident: $INPUT_TY:ty, $TZ:ident ) -> $OUTPUT_TY:ty {
+            $EXPR:expr
+        }
+    ) => {
+        $(#[$OUTER])* pub fn $OP($ARRAY: $INPUT_TY, $TZ: &Option<BaseTimeZone> ) -> $OUTPUT_TY {
+            handle_timestamp_fn($ARRAY, $TZ, $EXPR)
+        }
+    };
 }
 
-/// Extracts the days of month from Date16 array
-pub fn date16_to_day_of_month(array: &Date16Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(days_to_ymd(x? as i32).d)).collect())
-}
-
-/// Extracts the days of week from Date16 array
-pub fn date16_to_day_of_week(array: &Date16Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(days_to_weekday(x? as i32))).collect())
+def_datetime_fn! {
+    /// Extracts the years from Date16 array
+    fn date16_to_year(array: &Date16Array) -> Result<UInt16Array> {
+        |x| Some(days_to_year(x? as i32))
+    }
+    /// Extracts the months from Date16 array
+    fn date16_to_month(array: &Date16Array) -> Result<UInt8Array> {
+        |x| Some(days_to_ymd(x? as i32).m)
+    }
+    /// Extracts the days of year from Date16 array
+    fn date16_to_day_of_year(array: &Date16Array) -> Result<UInt16Array> {
+        |x| Some(days_to_ordinal(x? as i32))
+    }
+    /// Extracts the days of month from Date16 array
+    fn date16_to_day_of_month(array: &Date16Array) -> Result<UInt8Array> {
+        |x| Some(days_to_ymd(x? as i32).d)
+    }
+    /// Extracts the days of week from Date16 array
+    fn date16_to_day_of_week(array: &Date16Array) -> Result<UInt8Array> {
+        |x| Some(days_to_weekday(x? as i32))
+    }
+    /// Extracts the months from Date16 array
+    fn date16_to_quarter(array: &Date16Array) -> Result<UInt8Array> {
+        |x| Some(month_to_quarter(days_to_ymd(x? as i32).m))
+    }
+    /// Extracts the years from Timestamp32 array
+    fn timestamp32_to_year(array: &Timestamp32Array, tz) -> Result<UInt16Array> {
+        |x, tz| Some(unixtime_to_year(x? as i32, tz))
+    }
+    /// Extracts the months from Timestamp32 array
+    fn timestamp32_to_month(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
+        |x, tz| Some(unixtime_to_ymd(x? as i32, tz).m)
+    }
+    /// Extracts the days of year from Timestamp32 array
+    fn timestamp32_to_day_of_year(array: &Timestamp32Array, tz) -> Result<UInt16Array> {
+        |x, tz| Some(unixtime_to_ordinal(x? as i32, tz))
+    }
+    /// Extracts the days of month from Timestamp32 array
+    fn timestamp32_to_day_of_month(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
+        |x, tz| Some(unixtime_to_ymd(x? as i32, tz).d)
+    }
+    /// Extracts the days of week from Timestamp32 array
+    fn timestamp32_to_day_of_week(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
+        |x, tz| Some(unixtime_to_weekday(x? as i32, tz))
+    }
+    /// Extracts the months from Timestamp32 array
+    fn timestamp32_to_quarter(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
+        |x, tz| Some(month_to_quarter(unixtime_to_ymd(x? as i32, tz).m))
+    }
+    /// Extracts the hours from Timestamp32 array
+    fn timestamp32_to_hour(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
+        |x, tz| Some(unixtime_to_hms(x? as i32, tz).h)
+    }
+    /// Extracts the minutes from Timestamp32 array
+    fn timestamp32_to_minute(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
+        |x, tz| Some(unixtime_to_hms(x? as i32, tz).m)
+    }
+    /// Extracts the seconds from Timestamp32 array
+    fn timestamp32_to_second(array: &Timestamp32Array, _tz) -> Result<UInt8Array> {
+        |x, _tz| Some(unixtime_to_second(x? as i32))
+    }
 }
 
 fn month_to_quarter(month: u8) -> u8 {
     (month - 1) / 3 + 1
 }
 
-/// Extracts the months from Date16 array
-pub fn date16_to_quarter(array: &Date16Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(month_to_quarter(days_to_ymd(x? as i32).m))).collect())
-}
-
-/// Extracts the years from Timestamp32 array
-pub fn timestamp32_to_year(array: &Timestamp32Array) -> Result<UInt16Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_year(x? as i32))).collect())
-}
-
-/// Extracts the months from Timestamp32 array
-pub fn timestamp32_to_month(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_ymd(x? as i32).m)).collect())
-}
-
-/// Extracts the days of year from Timestamp32 array
-pub fn timestamp32_to_day_of_year(array: &Timestamp32Array) -> Result<UInt16Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_ordinal(x? as i32))).collect())
-}
-
-/// Extracts the days of month from Timestamp32 array
-pub fn timestamp32_to_day_of_month(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_ymd(x? as i32).d)).collect())
-}
-
-/// Extracts the days of week from Timestamp32 array
-pub fn timestamp32_to_day_of_week(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_weekday(x? as i32))).collect())
-}
-
-/// Extracts the months from Timestamp32 array
-pub fn timestamp32_to_quarter(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(month_to_quarter(unixtime_to_ymd(x? as i32).m))).collect())
-}
-
-/// Extracts the hours from Timestamp32 array
-pub fn timestamp32_to_hour(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_hms(x? as i32).h)).collect())
-}
-
-/// Extracts the minutes from Timestamp32 array
-pub fn timestamp32_to_minute(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_hms(x? as i32).m)).collect())
-}
-
-/// Extracts the seconds from Timestamp32 array
-pub fn timestamp32_to_second(array: &Timestamp32Array) -> Result<UInt8Array> {
-    Ok(array.iter().map(|x| Some(unixtime_to_second(x? as i32))).collect())
-}
-
 macro_rules! wrap_datetime_fn {
     ( $(
         $(#[$OUTER:meta])* $NAME:literal => fn $FUNC:ident {
-            $( $DATA_TYPE:pat => fn $OP:ident($INPUT_TY:ty) -> $OUTPUT_TY:ty, )*
+            $( $DATA_TYPE:pat => fn $OP:ident($INPUT_TY:ty $(, $TZ:ident)? ) -> $OUTPUT_TY:ty, )*
         }
     )* ) => { $(
         $(#[$OUTER])*
         pub fn $FUNC(args: &[ColumnarValue]) -> $crate::error::Result<ColumnarValue> {
             match args[0].data_type() {
                 $(
-                data_type @ $DATA_TYPE => if let ColumnarValue::Array(array) = &args[0] {
+                $DATA_TYPE => if let ColumnarValue::Array(array) = &args[0] {
                     if let Some(a) = array.as_any().downcast_ref::<$INPUT_TY>() {
-                        let res: $OUTPUT_TY = $OP(a)?;
+                        let res: $OUTPUT_TY = $OP(a $(, &$TZ)? )?;
                         Ok(ColumnarValue::Array(Arc::new(res)))
                     } else {
                         return Err(DataFusionError::Internal(format!(
                             "failed to downcast to {:?}",
-                            data_type,
+                            args[0].data_type(),
                         )));
                     }
                 } else {
                     return Err(DataFusionError::Internal(format!(
                         "failed to downcast to {:?}",
-                        data_type,
+                        args[0].data_type(),
                     )));
                 },
                 )*
@@ -267,47 +323,49 @@ wrap_datetime_fn! {
     /// wrapping to backend to_year logics
     "toYear" => fn expr_to_year {
         DataType::Date16 => fn date16_to_year(Date16Array) -> UInt16Array,
-        DataType::Timestamp32(_) => fn timestamp32_to_year(Timestamp32Array) -> UInt16Array,
+        DataType::Timestamp32(tz) => fn timestamp32_to_year(Timestamp32Array, tz) -> UInt16Array,
     }
     /// wrapping to backend to_quarter logics
     "toQuarter" => fn expr_to_quarter {
         DataType::Date16 => fn date16_to_quarter(Date16Array) -> UInt8Array,
-        DataType::Timestamp32(_) => fn timestamp32_to_quarter(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) => fn timestamp32_to_quarter(Timestamp32Array, tz) -> UInt8Array,
     }
     /// wrapping to backend to_month logics
     "toMonth" => fn expr_to_month {
         DataType::Date16 => fn date16_to_month(Date16Array) -> UInt8Array,
-        DataType::Timestamp32(_) => fn timestamp32_to_month(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) => fn timestamp32_to_month(Timestamp32Array, tz) -> UInt8Array,
     }
     /// wrapping to backend to_day_of_year logics
     "toDayOfYear" => fn expr_to_day_of_year {
         DataType::Date16 => fn date16_to_day_of_year(Date16Array) -> UInt16Array,
-        DataType::Timestamp32(_) => fn timestamp32_to_day_of_year(Timestamp32Array) -> UInt16Array,
+        DataType::Timestamp32(tz) =>
+            fn timestamp32_to_day_of_year(Timestamp32Array, tz) -> UInt16Array,
     }
     /// wrapping to backend to_day_of_month logics
     "toDayOfMonth" => fn expr_to_day_of_month {
         DataType::Date16 => fn date16_to_day_of_month(Date16Array) -> UInt8Array,
-        DataType::Timestamp32(_) => fn timestamp32_to_day_of_month(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) =>
+            fn timestamp32_to_day_of_month(Timestamp32Array, tz) -> UInt8Array,
     }
     /// wrapping to backend to_day_of_week logics
     "toDayOfWeek" => fn expr_to_day_of_week {
         DataType::Date16 => fn date16_to_day_of_week(Date16Array) -> UInt8Array,
-        DataType::Timestamp32(_) => fn timestamp32_to_day_of_week(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) =>
+            fn timestamp32_to_day_of_week(Timestamp32Array, tz) -> UInt8Array,
     }
     /// wrapping to backend to_hour logics
     "toHour" => fn expr_to_hour {
-        DataType::Timestamp32(_) => fn timestamp32_to_hour(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) => fn timestamp32_to_hour(Timestamp32Array, tz) -> UInt8Array,
     }
     /// wrapping to backend to_minute logics
     "toMinute" => fn expr_to_minute {
-        DataType::Timestamp32(_) => fn timestamp32_to_minute(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) => fn timestamp32_to_minute(Timestamp32Array, tz) -> UInt8Array,
     }
     /// wrapping to backend to_second logics
     "toSecond" => fn expr_to_second {
-        DataType::Timestamp32(_) => fn timestamp32_to_second(Timestamp32Array) -> UInt8Array,
+        DataType::Timestamp32(tz) => fn timestamp32_to_second(Timestamp32Array, tz) -> UInt8Array,
     }
 }
-
 
 /// Returns true if string ends with suffix for utf-8.
 pub fn utf8_ends_with(args: &[ArrayRef]) -> Result<BooleanArray> {
@@ -368,7 +426,7 @@ macro_rules! wrap_string_fn {
                             ColumnarValue::Scalar(_) => acc,
                             ColumnarValue::Array(a) => Some(a.len()),
                         });
-                    
+
                     // to array
                     let args = if let Some(len) = len {
                         args.iter()
@@ -379,7 +437,7 @@ macro_rules! wrap_string_fn {
                             .map(|arg| arg.clone().into_array(1))
                             .collect::<Vec<ArrayRef>>()
                     };
-                
+
                     let res = $OP(&args)?;
                     Ok(ColumnarValue::Array(Arc::new(res)))
                 },)*

--- a/crates/datafusion/src/physical_plan/clickhouse.rs
+++ b/crates/datafusion/src/physical_plan/clickhouse.rs
@@ -243,35 +243,35 @@ def_datetime_fn! {
     }
     /// Extracts the years from Timestamp32 array
     fn timestamp32_to_year(array: &Timestamp32Array, tz) -> Result<UInt16Array> {
-        |x, tz| Some(unixtime_to_year(x? as i32, tz))
+        |x, tz| Some(unixtime_to_year(x? as i32, tz.offset()))
     }
     /// Extracts the months from Timestamp32 array
     fn timestamp32_to_month(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
-        |x, tz| Some(unixtime_to_ymd(x? as i32, tz).m)
+        |x, tz| Some(unixtime_to_ymd(x? as i32, tz.offset()).m)
     }
     /// Extracts the days of year from Timestamp32 array
     fn timestamp32_to_day_of_year(array: &Timestamp32Array, tz) -> Result<UInt16Array> {
-        |x, tz| Some(unixtime_to_ordinal(x? as i32, tz))
+        |x, tz| Some(unixtime_to_ordinal(x? as i32, tz.offset()))
     }
     /// Extracts the days of month from Timestamp32 array
     fn timestamp32_to_day_of_month(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
-        |x, tz| Some(unixtime_to_ymd(x? as i32, tz).d)
+        |x, tz| Some(unixtime_to_ymd(x? as i32, tz.offset()).d)
     }
     /// Extracts the days of week from Timestamp32 array
     fn timestamp32_to_day_of_week(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
-        |x, tz| Some(unixtime_to_weekday(x? as i32, tz))
+        |x, tz| Some(unixtime_to_weekday(x? as i32, tz.offset()))
     }
     /// Extracts the months from Timestamp32 array
     fn timestamp32_to_quarter(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
-        |x, tz| Some(month_to_quarter(unixtime_to_ymd(x? as i32, tz).m))
+        |x, tz| Some(month_to_quarter(unixtime_to_ymd(x? as i32, tz.offset()).m))
     }
     /// Extracts the hours from Timestamp32 array
     fn timestamp32_to_hour(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
-        |x, tz| Some(unixtime_to_hms(x? as i32, tz).h)
+        |x, tz| Some(unixtime_to_hms(x? as i32, tz.offset()).h)
     }
     /// Extracts the minutes from Timestamp32 array
     fn timestamp32_to_minute(array: &Timestamp32Array, tz) -> Result<UInt8Array> {
-        |x, tz| Some(unixtime_to_hms(x? as i32, tz).m)
+        |x, tz| Some(unixtime_to_hms(x? as i32, tz.offset()).m)
     }
     /// Extracts the seconds from Timestamp32 array
     fn timestamp32_to_second(array: &Timestamp32Array, _tz) -> Result<UInt8Array> {

--- a/crates/datafusion_tests/Cargo.toml
+++ b/crates/datafusion_tests/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
+base = { path = "../base" }
 arrow = { path = "../arrow", features = ["prettyprint"] }
 datafusion = { path = "../datafusion", features = ["simd"] }

--- a/crates/datafusion_tests/tests/clickhouse.rs
+++ b/crates/datafusion_tests/tests/clickhouse.rs
@@ -3,6 +3,7 @@ mod tests {
     use arrow::array::Array;
     use arrow::datatypes::Timestamp32Type;
     use arrow::{array::PrimitiveArray, datatypes::Date16Type};
+    use base::datetimes::BaseTimeZone;
     use datafusion::physical_plan::clickhouse::*;
 
     #[test]
@@ -112,7 +113,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(3601), None, Some(7202)].into();
 
-        let b = timestamp32_to_hour(&a).unwrap();
+        let b = timestamp32_to_hour(&a, &Some(BaseTimeZone::default())).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(1, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -127,7 +128,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_hour(&a).unwrap();
+            let b = timestamp32_to_hour(&a, &Some(BaseTimeZone::default())).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }
@@ -139,7 +140,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(301), None, Some(7802)].into();
 
-        let b = timestamp32_to_minute(&a).unwrap();
+        let b = timestamp32_to_minute(&a, &Some(BaseTimeZone::default())).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(5, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -154,7 +155,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_minute(&a).unwrap();
+            let b = timestamp32_to_minute(&a, &Some(BaseTimeZone::default())).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }
@@ -166,7 +167,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(325), None, Some(7849)].into();
 
-        let b = timestamp32_to_second(&a).unwrap();
+        let b = timestamp32_to_second(&a, &Some(BaseTimeZone::default())).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(25, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -181,7 +182,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_second(&a).unwrap();
+            let b = timestamp32_to_second(&a, &Some(BaseTimeZone::default())).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -7,7 +7,6 @@ pub trait IQueryState {}
 
 pub struct QueryState {
     pub copasss: Vec<Vec<Vec<CoPaInfo>>>,
-    pub tz_offset: i32,
     pub tid: Id,
     pub cis: Vec<(Id, BqlType)>,
 }
@@ -23,7 +22,6 @@ impl Default for QueryState {
     fn default() -> Self {
         QueryState {
             copasss: Vec::new(),
-            tz_offset: 0,
             tid: 0,
             cis: Vec::new(),
         }

--- a/crates/engine/tests/df_tests.rs
+++ b/crates/engine/tests/df_tests.rs
@@ -92,7 +92,6 @@ async fn run_ker_test_arrow(
 ) -> EngineResult<()> {
     // let sql = "select numbers from system.numbers limit 10";
     let mut qs = engine::types::QueryState::default();
-    qs.tz_offset = 8 * 3600;
 
     let timer = Instant::now();
 

--- a/crates/lightjit/src/builtins.rs
+++ b/crates/lightjit/src/builtins.rs
@@ -1,9 +1,9 @@
-use base::datetimes::{days_to_ymd, unixtime_to_ymd};
+use base::datetimes::{days_to_ymd, unixtime_to_ymd_utc};
 
 //FIXME expensive a little
 #[allow(non_snake_case)]
 pub fn toYYYY(ut: u64) -> u64 {
-    let ymd = unixtime_to_ymd(ut as i32);
+    let ymd = unixtime_to_ymd_utc(ut as i32);
     ymd.y as u64
 }
 
@@ -21,13 +21,13 @@ pub fn date_toYYYYMM(ut: u64) -> u64 {
 
 #[allow(non_snake_case)]
 pub fn toYYYYMM(ut: u64) -> u64 {
-    let ymd = unixtime_to_ymd(ut as i32);
+    let ymd = unixtime_to_ymd_utc(ut as i32);
     ymd.y as u64 * 100 + ymd.m as u64
 }
 
 #[allow(non_snake_case)]
 pub fn toYYYYMMDD(ut: u64) -> u64 {
-    let ymd = unixtime_to_ymd(ut as i32);
+    let ymd = unixtime_to_ymd_utc(ut as i32);
     ymd.y as u64 * 10000 + ymd.m as u64 * 100 + ymd.d as u64
 }
 

--- a/crates/lightjit/src/builtins.rs
+++ b/crates/lightjit/src/builtins.rs
@@ -1,9 +1,10 @@
-use base::datetimes::{days_to_ymd, unixtime_to_ymd_utc};
+use base::datetimes::{days_to_ymd, unixtime_to_ymd};
 
+//FIXME do we want to use the default tz in mgmt? rather than UTC
 //FIXME expensive a little
 #[allow(non_snake_case)]
 pub fn toYYYY(ut: u64) -> u64 {
-    let ymd = unixtime_to_ymd_utc(ut as i32);
+    let ymd = unixtime_to_ymd(ut as i32, 0);
     ymd.y as u64
 }
 
@@ -21,13 +22,13 @@ pub fn date_toYYYYMM(ut: u64) -> u64 {
 
 #[allow(non_snake_case)]
 pub fn toYYYYMM(ut: u64) -> u64 {
-    let ymd = unixtime_to_ymd_utc(ut as i32);
+    let ymd = unixtime_to_ymd(ut as i32, 0);
     ymd.y as u64 * 100 + ymd.m as u64
 }
 
 #[allow(non_snake_case)]
 pub fn toYYYYMMDD(ut: u64) -> u64 {
-    let ymd = unixtime_to_ymd_utc(ut as i32);
+    let ymd = unixtime_to_ymd(ut as i32, 0);
     ymd.y as u64 * 10000 + ymd.m as u64 * 100 + ymd.d as u64
 }
 

--- a/crates/meta/src/confs.rs
+++ b/crates/meta/src/confs.rs
@@ -46,6 +46,7 @@ pub struct Server {
     pub ip_addr: String,
     #[serde(default = "Server::default_port")]
     pub port: u16,
+    pub timezone: Option<String>,
 }
 
 impl Server {
@@ -63,6 +64,7 @@ impl Default for Server {
         Server {
             ip_addr: Server::default_ip_addr(),
             port: Server::default_port(),
+            ..Default::default()
         }
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -23,6 +23,7 @@ lightjit = { path = "../lightjit" }
 baselog = { git = "https://github.com/tensorbase/baselog.git", branch = "main" }
 clickhouse-rs-cityhash-sys = "0.1.2"
 arrow = { path = "../arrow" }
+datafusion = { path = "../datafusion", features = ["simd"] }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/runtime/src/ch/messages.rs
+++ b/crates/runtime/src/ch/messages.rs
@@ -260,7 +260,7 @@ fn response_hello(
     wb.write_varint(DBMS_VERSION_MAJOR);
     wb.write_varint(DBMS_VERSION_MINOR);
     wb.write_varint(REVISION);
-    wb.write_str(&BMS.timezone_sys);
+    wb.write_str(BMS.timezone.name());
     wb.write_str(DBMS_NAME);
     wb.write_varint(DBMS_VERSION_PATCH);
 

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -967,7 +967,8 @@ fn parse_literal_as_bytes(lit: &str, btyp: BqlType) -> BaseRtResult<Vec<u8>> {
             _ => return Err(BaseRtError::UnsupportedValueConversion),
         },
         BqlType::DateTime => {
-            let ut = parse_to_epoch(lit)?;
+            let tz_offset = BMS.timezone.offset();
+            let ut = parse_to_epoch(lit, tz_offset)?;
             let v = ut.to_le_bytes();
             rt.extend(&v);
         }

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -1,10 +1,10 @@
 use base::{
-    codec::encode_ascii_bytes_vec_short, datetimes::parse_to_epoch, mem::SyncPointer,
+    codec::encode_ascii_bytes_vec_short,
+    datetimes::{parse_to_epoch, BaseTimeZone},
+    mem::SyncPointer,
     strings::s,
 };
 use bytes::BytesMut;
-use chrono::{Local, Offset, TimeZone};
-use chrono_tz::{OffsetComponents, OffsetName, TZ_VARIANTS};
 use dashmap::DashMap;
 use lang::parse::{
     parse_command, parse_create_database, parse_create_table, parse_desc_table,
@@ -26,6 +26,7 @@ use std::{
     panic::panic_any,
     path::Path,
     pin::Pin,
+    str::FromStr,
     sync::Mutex,
     time::Instant,
 };
@@ -40,6 +41,7 @@ use crate::{
     },
     errs::{BaseRtError, BaseRtResult},
 };
+use datafusion::physical_plan::clickhouse::DEFAULT_TIMEZONE;
 
 pub static READ: SyncOnceCell<
     fn(
@@ -48,7 +50,6 @@ pub static READ: SyncOnceCell<
         query_id: &str,
         current_db: &str,
         p: Pair<Rule>,
-        tz_offset: i32,
     ) -> BaseRtResult<Vec<Block>>,
 > = SyncOnceCell::new();
 
@@ -188,8 +189,7 @@ pub struct BaseMgmtSys<'a> {
     pub meta_store: MetaStore,
     pub part_store: PartStore<'a>,
     pub ptk_exprs_reg: DashMap<Id, SyncPointer<u8>, BuildPtkExprsHasher>,
-    pub timezone_sys: String,
-    pub timezone_sys_offset: i32,
+    pub timezone: BaseTimeZone,
 }
 
 impl<'a> BaseMgmtSys<'a> {
@@ -198,26 +198,13 @@ impl<'a> BaseMgmtSys<'a> {
         let meta_store =
             MetaStore::new(ms_path).map_err(|e| BaseRtError::WrappingMetaError(e))?;
         let part_store = PartStore::new(ms_path, &conf.system.data_dirs)?;
-        let (timezone_sys, timezone_sys_offset) = {
-            let mut ret = ("GMT".to_string(), 0);
-            let ctz = Local::now().offset().fix();
-            for tz in TZ_VARIANTS.iter() {
-                let some_time = tz.ymd(1, 1, 1).and_hms(0, 0, 0);
-                let stz = some_time.offset().fix();
-                if stz == ctz {
-                    let tz_sys = some_time.offset().tz_id();
-                    let tz_sys_offset =
-                        some_time.offset().base_utc_offset().num_seconds() as i32;
-                    log::info!(
-                        "current timezone sets to {}",
-                        tz_sys,
-                        // tz_sys_offset
-                    );
-                    ret = (tz_sys.to_string(), tz_sys_offset)
-                }
-            }
-            ret
+        let timezone = match &conf.server.timezone {
+            Some(tz_name) => BaseTimeZone::from_str(&tz_name)?,
+            _ => BaseTimeZone::from_local().unwrap_or_default(),
         };
+        DEFAULT_TIMEZONE.get_or_init(|| timezone.clone());
+        log::info!("current timezone sets to {}", timezone);
+
         //prepare two system level databases
         let res = meta_store.new_db("system");
         match res {
@@ -265,8 +252,7 @@ impl<'a> BaseMgmtSys<'a> {
             meta_store,
             part_store,
             ptk_exprs_reg,
-            timezone_sys,
-            timezone_sys_offset,
+            timezone,
         })
     }
 
@@ -591,16 +577,7 @@ impl<'a> BaseMgmtSys<'a> {
                 command_insert_into_gen_header(&tab, &qtn, ms, &mut blk, dbn, tn)?;
             }
             Some(vt) => {
-                command_insert_into_gen_block(
-                    &tab,
-                    &qtn,
-                    ms,
-                    &mut blk,
-                    dbn,
-                    tn,
-                    vt,
-                    self.timezone_sys_offset,
-                )?;
+                command_insert_into_gen_block(&tab, &qtn, ms, &mut blk, dbn, tn, vt)?;
             }
         }
 
@@ -791,14 +768,7 @@ impl<'a> BaseMgmtSys<'a> {
         // raw_query: String,
     ) -> BaseRtResult<BaseCommandKind> {
         let read = READ.get().unwrap();
-        let blks = read(
-            &self.meta_store,
-            &self.part_store,
-            query_id,
-            current_db,
-            p,
-            self.timezone_sys_offset,
-        )?;
+        let blks = read(&self.meta_store, &self.part_store, query_id, current_db, p)?;
         Ok(BaseCommandKind::Query(blks))
     }
 
@@ -931,11 +901,7 @@ fn command_insert_into_gen_header(
     Ok(())
 }
 
-fn parse_literal_as_bytes(
-    lit: &str,
-    btyp: BqlType,
-    tz_offset: i32,
-) -> BaseRtResult<Vec<u8>> {
+fn parse_literal_as_bytes(lit: &str, btyp: BqlType) -> BaseRtResult<Vec<u8>> {
     let mut rt = Vec::new();
     match btyp {
         BqlType::UInt(bits) => match bits {
@@ -1001,10 +967,7 @@ fn parse_literal_as_bytes(
             _ => return Err(BaseRtError::UnsupportedValueConversion),
         },
         BqlType::DateTime => {
-            let ut = (parse_to_epoch(lit)
-                .map_err(|_e| BaseRtError::InsertIntoValueParsingError)?
-                as i64
-                - (tz_offset as i64)) as u32;
+            let ut = parse_to_epoch(lit)?;
             let v = ut.to_le_bytes();
             rt.extend(&v);
         }
@@ -1026,7 +989,6 @@ fn command_insert_into_gen_block(
     dbn: &str,
     tn: &str,
     rows: Vec<Vec<String>>,
-    tz_offset: i32,
 ) -> BaseRtResult<()> {
     let nr = rows.len();
     if tab.columns.len() != 0 {
@@ -1052,7 +1014,7 @@ fn command_insert_into_gen_block(
         //     let mut data: Vec<u8> = Vec::new();
         //     for i in 0..nr {
         //         let lit = &rows[i][ic];
-        //         let bs = parse_literal_as_bytes(lit, btype, tz_offset)?;
+        //         let bs = parse_literal_as_bytes(lit, btype)?;
         //         data.extend(bs);
         //     }
         //     blk.columns.push(Column {
@@ -1085,7 +1047,7 @@ fn command_insert_into_gen_block(
             let mut data: Vec<u8> = Vec::new();
             for i in 0..nr {
                 let lit = &rows[i][ic];
-                let bs = parse_literal_as_bytes(lit, btype, tz_offset)?;
+                let bs = parse_literal_as_bytes(lit, btype)?;
                 data.extend(bs);
             }
             blk.columns.push(Column {

--- a/crates/runtime/src/read.rs
+++ b/crates/runtime/src/read.rs
@@ -11,13 +11,11 @@ pub fn query(
     query_id: &str,
     current_db: &str,
     p: Pair<Rule>,
-    tz_offset: i32,
 ) -> BaseRtResult<Vec<Block>> {
     let timer = Instant::now();
     let query_id = query_id.replace("-", "_");
     let raw_query = p.as_str().to_string();
     let mut qs = QueryState::default();
-    qs.tz_offset = tz_offset;
 
     // debug_assert!(ret == 0);
     let res = engine::run(

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -176,7 +176,7 @@ fn gen_part_idxs<T: 'static + Sized + Copy>(
                                                                                         // let siz_typ_ptk = mem::size_of::<T>();
     let ptk_expr_fn = unsafe { mem::transmute::<_, fn(T) -> u64>(ptk_expr_fn_ptr) };
     let is_datetime_typ = matches!(ctyp_ptk, BqlType::DateTime);
-    let tz_ofs = BMS.timezone_sys_offset as i64;
+    let tz_ofs = BMS.timezone.offset() as i64;
     for j in 0..nr {
         //FIXME
         let ptk = if is_datetime_typ {

--- a/crates/tests_integ/Cargo.toml
+++ b/crates/tests_integ/Cargo.toml
@@ -30,6 +30,7 @@ paste = "1.0.1"
 baselog = { git = "https://github.com/tensorbase/baselog.git", branch = "main" }
 walkdir = "2.3.1"
 chrono = "0.4"
+chrono-tz = "0.5"
 
 [[bin]]
 name = "sql_test_runner"

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -1,7 +1,8 @@
 use client::prelude::*;
 use client::{prelude::errors, types::SqlType};
 mod common;
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use chrono_tz::Tz;
 use client::prelude::types::Decimal;
 use common::get_pool;
 // macro_rules! get {
@@ -792,14 +793,20 @@ async fn tests_integ_date_time_functions() -> errors::Result<()> {
         Utc.ymd(2021, 8, 31),
         Utc.ymd(2021, 6, 27),
     ];
+
+    let tz = Tz::Etc__GMTMinus8;
     let data_b = vec![
-        Utc.ymd(2010, 1, 1).and_hms(1, 1, 1),
-        Utc.ymd(2011, 2, 28).and_hms(2, 5, 6),
-        Utc.ymd(2012, 2, 29).and_hms(23, 59, 59),
-        Utc.ymd(2012, 3, 4).and_hms(5, 6, 7),
-        Utc.ymd(2021, 8, 31).and_hms(14, 32, 3),
-        Utc.ymd(2021, 6, 27).and_hms(17, 44, 32),
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+        NaiveDate::from_ymd(2011, 2, 28).and_hms(2, 5, 6),
+        NaiveDate::from_ymd(2012, 2, 29).and_hms(23, 59, 59),
+        NaiveDate::from_ymd(2012, 3, 4).and_hms(5, 6, 7),
+        NaiveDate::from_ymd(2021, 8, 31).and_hms(14, 32, 3),
+        NaiveDate::from_ymd(2021, 6, 27).and_hms(17, 44, 32),
     ];
+    let data_b: Vec<_> = data_b
+        .into_iter()
+        .map(|b| Utc.from_utc_datetime(&tz.from_local_datetime(&b).unwrap().naive_utc()))
+        .collect();
     let years = vec![2010, 2011, 2012, 2012, 2021, 2021];
     let months = vec![1, 2, 2, 3, 8, 6];
     let quarters = vec![1, 1, 1, 1, 3, 2];


### PR DESCRIPTION
Signed-off-by: Frank King <frankking1729@gmail.com>

As the discussion in #27, this PR adds a global default timezone with an offset.

What this PR does:
- when timestamps are parsing from string, the offset subtracts,
- when timestamps are interpreted as days/hours via the `toDayOfMonth/toHour` functions etc., the offset is added.

What this PR does **NOT** yet:
- when timestamps are displayed as a string, the offset is NOT added yet.