### PR TITLE
fix `select *` logical error 

### DIFF
--- a/crates/engine/src/datafusions.rs
+++ b/crates/engine/src/datafusions.rs
@@ -75,7 +75,7 @@ pub(crate) fn run(
         // *cid, ci.data_type
         let mut cis = Vec::new();
         let mut fields = Vec::new();
-        if cols.len() != 0 {
+        if cols.len() != 0 && !tctx.has_select_all {
             for cn in &cols {
                 let qcn = if cn.contains('.') {
                     // ms.cid_by_qname(&cn).ok_or(EngineError::ColumnNotExist)?


### PR DESCRIPTION
Signed-off-by: nautaa <870284156@qq.com>
If we use `select * `  with other column conditions, we will get the wrong result.
For example:
```
create table test (a UInt64, b UInt64) ENGINE = BaseStorage
insert into test values (1,1),(2,2)
TensorBase :) select * from test where b=1

SELECT *
FROM test
WHERE b = 1

Query id: 03beb4cb-b5e3-4318-b154-a39f9950108e

┌─b─┐
│ 1 │
└───┘
```
This PR fix it.
