### PR TITLE
REFACTOR(datafusion): simplify the `wrap_datetime_fn` macro

### DIFF
--- a/crates/datafusion/src/physical_plan/clickhouse.rs
+++ b/crates/datafusion/src/physical_plan/clickhouse.rs
@@ -505,7 +505,7 @@ fn string_to_date16<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<Date1
     let string_array = downcast_string_arg!(args[0], "string", T);
     let start_idx = match T::DATA_TYPE {
         DataType::Utf8 => 0,
-        DataType::LargeUtf8 => 1,
+        DataType::LargeUtf8 => 1,//FIXME for TB string, len header is varied, not 1
         _ => {
             return Err(DataFusionError::Execution(
                 "Invalid string offset size".to_string(),

--- a/crates/datafusion_tests/tests/clickhouse.rs
+++ b/crates/datafusion_tests/tests/clickhouse.rs
@@ -4,7 +4,6 @@ mod tests {
     use arrow::array::GenericStringArray;
     use arrow::datatypes::{Int64Type, Timestamp32Type};
     use arrow::{array::PrimitiveArray, datatypes::Date16Type};
-    use base::datetimes::BaseTimeZone;
     use datafusion::physical_plan::clickhouse::*;
     use std::sync::Arc;
 
@@ -13,7 +12,7 @@ mod tests {
         // test to_date(Timestamp32)
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(536457600), None, Some(1609459200)].into();
-        let b = timestamp32_to_date(&a, Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_date(&a, Some(0)).unwrap();
 
         assert_eq!(0, b.value(0));
         assert_eq!(6209, b.value(1)); // 1987-01-01
@@ -76,7 +75,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_date(&a, Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_date(&a, Some(0)).unwrap();
             s += b.len() as usize;
         }
 
@@ -190,7 +189,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(3601), None, Some(7202)].into();
 
-        let b = timestamp32_to_hour(&a, Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_hour(&a, Some(0)).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(1, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -205,7 +204,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_hour(&a, Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_hour(&a, Some(0)).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }
@@ -217,7 +216,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(301), None, Some(7802)].into();
 
-        let b = timestamp32_to_minute(&a, Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_minute(&a, Some(0)).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(5, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -232,7 +231,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_minute(&a, Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_minute(&a, Some(0)).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }
@@ -244,7 +243,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(325), None, Some(7849)].into();
 
-        let b = timestamp32_to_second(&a, Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_second(&a, Some(0)).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(25, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -259,7 +258,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_second(&a, Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_second(&a, Some(0)).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }

--- a/crates/datafusion_tests/tests/clickhouse.rs
+++ b/crates/datafusion_tests/tests/clickhouse.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use arrow::array::Array;
-    use arrow::array::GenericStringArray;
-    use arrow::datatypes::{Int64Type, Timestamp32Type};
-    use arrow::{array::PrimitiveArray, datatypes::Date16Type};
+    use arrow::{
+        array::{Array, LargeStringArray, PrimitiveArray, StringArray},
+        datatypes::{Date16Type, Int64Type, Timestamp32Type},
+    };
     use datafusion::physical_plan::clickhouse::*;
     use std::sync::Arc;
 
@@ -30,29 +30,7 @@ mod tests {
         assert_eq!(0, b.value(4)); // 2021-01-01
 
         // test to_date(Utf8)
-        let a: GenericStringArray<i64> =
-            vec![Some("1970-1-1"), Some("1987-01-01"), Some("2021-01-01")].into();
-        let a = Arc::new(a);
-        let b = large_utf8_to_date(&[a]).unwrap();
-
-        assert_eq!(0, b.value(0));
-        assert_eq!(6209, b.value(1));
-        assert_eq!(18628, b.value(2));
-
-        let a: GenericStringArray<i64> =
-            vec![Some("err"), Some("1987-01-01"), Some("2021-01-01")].into();
-        let a = Arc::new(a);
-        assert!(large_utf8_to_date(&[a]).is_err());
-
-        let a: GenericStringArray<i64> =
-            vec![Some("\u{10}1987-01-01"), Some("\u{10}2021-01-01")].into();
-        let a = Arc::new(a);
-        let b = large_utf8_to_date(&[a]).unwrap();
-        assert_eq!(6209, b.value(0));
-        assert_eq!(18628, b.value(1));
-
-        // test to_date(LargeUtf8)
-        let a: GenericStringArray<i32> =
+        let a: StringArray =
             vec![Some("1970-1-1"), Some("1987-01-01"), Some("2021-01-01")].into();
         let a = Arc::new(a);
         let b = utf8_to_date(&[a]).unwrap();
@@ -61,10 +39,39 @@ mod tests {
         assert_eq!(6209, b.value(1));
         assert_eq!(18628, b.value(2));
 
-        let a: GenericStringArray<i32> =
+        let a: StringArray =
             vec![Some("err"), Some("1987-01-01"), Some("2021-01-01")].into();
         let a = Arc::new(a);
         assert!(utf8_to_date(&[a]).is_err());
+
+        // test to_date(LargeUtf8)
+        let a: LargeStringArray =
+            vec![Some("\u{10}1987-01-01"), Some("\u{10}2021-01-01")].into();
+        let a = Arc::new(a);
+        let b = large_utf8_to_date(&[a]).unwrap();
+        assert_eq!(6209, b.value(0));
+        assert_eq!(18628, b.value(1));
+
+        let a: LargeStringArray = vec![
+            Some("\u{3}err"),
+            Some("\u{10}1987-01-01"),
+            Some("\u{10}2021-01-01"),
+        ]
+        .into();
+        let a = Arc::new(a);
+        assert!(large_utf8_to_date(&[a]).is_err());
+
+        let a: LargeStringArray = vec![
+            Some("\u{8}1970-1-1"),
+            Some("\u{10}1987-01-01"),
+            Some("\u{10}2021-01-01"),
+        ]
+        .into();
+        let a = Arc::new(a);
+        let b = large_utf8_to_date(&[a]).unwrap();
+        assert_eq!(0, b.value(0));
+        assert_eq!(6209, b.value(1));
+        assert_eq!(18628, b.value(2));
     }
 
     #[test]

--- a/crates/datafusion_tests/tests/clickhouse.rs
+++ b/crates/datafusion_tests/tests/clickhouse.rs
@@ -13,7 +13,7 @@ mod tests {
         // test to_date(Timestamp32)
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(536457600), None, Some(1609459200)].into();
-        let b = timestamp32_to_date(&a, &Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_date(&a, Some(BaseTimeZone::default())).unwrap();
 
         assert_eq!(0, b.value(0));
         assert_eq!(6209, b.value(1)); // 1987-01-01
@@ -76,7 +76,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_date(&a, &Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_date(&a, Some(BaseTimeZone::default())).unwrap();
             s += b.len() as usize;
         }
 
@@ -190,7 +190,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(3601), None, Some(7202)].into();
 
-        let b = timestamp32_to_hour(&a, &Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_hour(&a, Some(BaseTimeZone::default())).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(1, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -205,7 +205,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_hour(&a, &Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_hour(&a, Some(BaseTimeZone::default())).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }
@@ -217,7 +217,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(301), None, Some(7802)].into();
 
-        let b = timestamp32_to_minute(&a, &Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_minute(&a, Some(BaseTimeZone::default())).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(5, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -232,7 +232,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_minute(&a, &Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_minute(&a, Some(BaseTimeZone::default())).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }
@@ -244,7 +244,7 @@ mod tests {
         let a: PrimitiveArray<Timestamp32Type> =
             vec![Some(0), Some(325), None, Some(7849)].into();
 
-        let b = timestamp32_to_second(&a, &Some(BaseTimeZone::default())).unwrap();
+        let b = timestamp32_to_second(&a, Some(BaseTimeZone::default())).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(25, b.value(1));
         assert_eq!(false, b.is_valid(2));
@@ -259,7 +259,7 @@ mod tests {
         let ts = ::std::time::Instant::now();
         let mut s = 0;
         for _ in 0..100 {
-            let b = timestamp32_to_second(&a, &Some(BaseTimeZone::default())).unwrap();
+            let b = timestamp32_to_second(&a, Some(BaseTimeZone::default())).unwrap();
             // let b = arrow::compute::kernels::temporal::year(&a).unwrap();
             s += b.len() as usize;
         }


### PR DESCRIPTION
@jinmingjian @pandaplusplus 
After #173, the macros in `clickhouse.rs` in A-DF shows to become too complicated. So I simplified the wrapping macro to contain only a array downcast process.