### PR TITLE
support bool-valued func in where clause

### DIFF
--- a/crates/lang/src/bql.pest
+++ b/crates/lang/src/bql.pest
@@ -271,6 +271,7 @@ comp_expr = {
     comp_expr_is_null |
     comp_expr_is_not_null |
     comp_expr_cmp |
+    func_call_expr |
     qualified_name
 }
 

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -1888,5 +1888,20 @@ limit
             *
             */
         }
+
+        #[test]
+        fn test_func_call_as_value() {
+            let c = "SELECT
+            id,
+            nick_name
+          FROM
+            person
+          WHERE
+            endsWith(nick_name, 'name')
+";
+            let pairs =
+                BqlParser::parse(Rule::cmd_list, c).unwrap_or_else(|e| panic!("{}", e));
+            println!("{}", pretty_parse_tree(pairs));
+        }
     }
 }


### PR DESCRIPTION
 As #172, sql-parser support function bool-valued in where clause, but tb's pest parse not support this. 
three solutions(bql.pest): 
1.  modify `comp_expr_cmp`. ( `comp_expr_cmp = { comp_expr_cmp_operand ~( comp_op ~ comp_expr_cmp_operand)? }`)
2.  add `expr` after `comp_expr_cmp` in `comp_expr` statment
3.  add `func_call_expr` after `comp_expr_cmp` in `comp_expr` statment

I think third one is better, it has smaller impact(just function call) than others.