### PR TITLE
enhance tempfile created on test case test_mm_file_ro

### DIFF
--- a/crates/base/proc_macro/src/lib.rs
+++ b/crates/base/proc_macro/src/lib.rs
@@ -186,8 +186,7 @@ pub fn async_test(
     );
     let afn_name = format!("{}", afn.sig.ident);
     let id_afn_name: TokenStream = afn_name.parse().unwrap();
-    let id_patched_afn_name: TokenStream =
-        (afn_name.to_string() + "_async_").parse().unwrap();
+    let id_patched_afn_name: TokenStream = (afn_name + "_async_").parse().unwrap();
     afn.sig.ident = syn::parse2(id_patched_afn_name.clone()).unwrap();
 
     let rt = quote! {

--- a/crates/base/src/datetimes.rs
+++ b/crates/base/src/datetimes.rs
@@ -64,7 +64,7 @@ impl FromStr for TimeZoneId {
                 (minute * 60 + hour * 3600) * sign
             }
             _ => Self::calc_offset_of_tz(
-                Tz::from_str(&tz_name)
+                Tz::from_str(tz_name)
                     .map_err(|_| BaseError::InvalidTimeZone(tz_name.to_string()))?,
             ),
         };
@@ -128,7 +128,7 @@ impl TimeZoneId {
         });
         match ctzn_opt {
             Some(name) => name,
-            None => panic!("Can not find a valid timezone name?")
+            None => panic!("Can not find a valid timezone name?"),
         }
     }
 
@@ -548,7 +548,7 @@ mod unit_tests {
         let time = "2021-07-03 15:03:28";
         let epoch = 1625324608;
         for tz in timezones {
-            let epoch_with_tz = parse_to_epoch(&time, tz.offset()).unwrap() as i32;
+            let epoch_with_tz = parse_to_epoch(time, tz.offset()).unwrap() as i32;
             println!(
                 "epoch_with_tz - epoch = {}, offset = {}",
                 epoch_with_tz - epoch,

--- a/crates/base/src/strings.rs
+++ b/crates/base/src/strings.rs
@@ -116,19 +116,19 @@ impl PutIntoBytes for Vec<u8> {
 
 impl PutIntoBytes for &Vec<u8> {
     fn put_into_bytes(self, sbuf: &mut Vec<u8>) {
-        sbuf.extend_from_slice(&self);
+        sbuf.extend_from_slice(self);
     }
 }
 
 impl PutIntoBytes for &mut Vec<u8> {
     fn put_into_bytes(self, sbuf: &mut Vec<u8>) {
-        sbuf.extend_from_slice(&self);
+        sbuf.extend_from_slice(self);
     }
 }
 
 impl PutIntoBytes for &[u8] {
     fn put_into_bytes(self, sbuf: &mut Vec<u8>) {
-        sbuf.extend_from_slice(&self);
+        sbuf.extend_from_slice(self);
     }
 }
 
@@ -236,6 +236,6 @@ mod unit_tests {
     fn test_bytes_to_cstring() {
         let cs = super::bytes_to_cstring(b"abc".to_vec());
         crate::debug!(&cs);
-        assert_eq!(cs, CString::new("abc").unwrap())
+        assert_eq!(cs, CString::new("abc").unwrap());
     }
 }

--- a/crates/base/tests/proc_macro_tests.rs
+++ b/crates/base/tests/proc_macro_tests.rs
@@ -1,6 +1,6 @@
 // #![recursion_limit="512"] //macros bang?
 use base::strings::{bs, bytes_to_cstring, s};
-use base::{debug, with_timer, with_timer_print};
+use base::{with_timer, with_timer_print};
 use std::{ffi::CString, thread, time};
 
 #[test]

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -204,7 +204,7 @@ impl<'a> BaseMgmtSys<'a> {
             Some(tz_name) => TimeZoneId::from_str(&tz_name)?,
             _ => TimeZoneId::from_local().unwrap_or_default(),
         };
-        DEFAULT_TIMEZONE.get_or_init(|| timezone );
+        DEFAULT_TIMEZONE.get_or_init(|| timezone);
         let timezone_name = timezone.name_ch();
         log::info!("current timezone sets to {}", timezone_name);
 


### PR DESCRIPTION
1. use libc::tmpfile() create tempfile instead of string concat of std::env::temp_dir()

file created by tempfile() would **automatically deleted** when it is closed or the program terminates.

https://github.com/tensorbase/tensorbase/blob/043c337edd0d898031f7ba3facfaba888beb1d43/crates/base/src/mmap.rs#L109-L113

2. Fix some clippy lints

eg. [lint unseparated_literal_suffix](https://rust-lang.github.io/rust-clippy/master/index.html#unseparated_literal_suffix)

we should write `0_u8` rather than `0u8`