### PR TITLE
FEAT(engine,client,lang,runtime,server): simple remote query function impl

### DIFF
--- a/crates/base/src/datetimes.rs
+++ b/crates/base/src/datetimes.rs
@@ -47,7 +47,7 @@ pub struct YMDHMS(pub i16, pub u8, pub u8, pub u8, pub u8, pub u8);
     Hash,
     Default,
 )]
-pub struct TimeZoneId(i32);
+pub struct TimeZoneId(pub i32);
 
 impl FromStr for TimeZoneId {
     type Err = BaseError;
@@ -91,7 +91,7 @@ impl TimeZoneId {
         })
     }
 
-    fn calc_offset_of_tz(tz: Tz) -> i32 {
+    pub fn calc_offset_of_tz(tz: Tz) -> i32 {
         tz.ymd(1, 1, 1)
             .and_hms(0, 0, 0)
             .offset()

--- a/crates/base/src/fuzz.rs
+++ b/crates/base/src/fuzz.rs
@@ -73,7 +73,7 @@ pub trait BoundedFuzzableVec<T: BoundedFuzzable> {
         Self::fuzz_bound_len_range(range, 0..32)
     }
     fn fuzz_bound_len(range: Range<T>, len: usize) -> Vec<T> {
-        Self::fuzz_bound_len_range(range, len..(len+1))
+        Self::fuzz_bound_len_range(range, len..(len + 1))
     }
     fn fuzz_bound_len_range(range: Range<T>, len_bound: Range<usize>) -> Vec<T>;
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -201,8 +201,12 @@ impl Inner {
     }
 
     #[inline]
-    fn setup_stream(socket: &TcpStream, options: &Options) -> io::Result<()> {
-        socket.set_linger(options.keepalive)?;
+    fn setup_stream(socket: &TcpStream, _options: &Options) -> io::Result<()> {
+        // TODO: wait for the support in the std
+        // https://github.com/rust-lang/rust/issues/69774
+        // https://github.com/tokio-rs/tokio/pull/3146
+        // https://github.com/async-rs/async-std/issues/718
+        // socket.set_keepalive(options.keepalive)?;
         socket.set_nodelay(true)
     }
 

--- a/crates/client/src/prelude.rs
+++ b/crates/client/src/prelude.rs
@@ -6,14 +6,17 @@ pub use crate::{
     protocol::{
         block::{Block, ServerBlock},
         column::{Deserialize, Row},
+        Value, ValueRefEnum,
     },
 };
+
 pub mod types {
     pub use crate::protocol::value::{
         ValueDateTime, ValueDateTime64, ValueDecimal32, ValueDecimal64, ValueUuid,
     };
     #[cfg(feature = "int128")]
     pub use crate::types::Decimal128;
+    pub use crate::types::SqlType;
     pub use crate::types::{Decimal, Decimal32, Decimal64, DecimalBits};
 }
 pub mod errors {

--- a/crates/client/src/protocol/block.rs
+++ b/crates/client/src/protocol/block.rs
@@ -191,8 +191,8 @@ impl<'b> Block<'b> {
 /// driver should validate the Block against server table structure
 /// before it been sent to server.
 pub struct BlockColumnHeader {
-    pub(crate) field: Field,
-    pub(crate) name: String,
+    pub field: Field,
+    pub name: String,
 }
 
 impl fmt::Debug for BlockColumnHeader {
@@ -206,12 +206,12 @@ impl fmt::Debug for BlockColumnHeader {
 
 /// input Block column data.
 pub struct BlockColumn {
-    pub(crate) header: BlockColumnHeader,
-    pub(crate) data: Box<dyn AsInColumn>,
+    pub header: BlockColumnHeader,
+    pub data: Box<dyn AsInColumn>,
 }
 
 impl BlockColumn {
-    pub(crate) fn into_header(self) -> BlockColumnHeader {
+    pub fn into_header(self) -> BlockColumnHeader {
         self.header
     }
 
@@ -231,9 +231,9 @@ impl std::fmt::Debug for BlockColumn {
 
 #[derive(Debug)]
 pub struct ServerBlock {
-    pub(crate) columns: Vec<BlockColumn>,
-    pub(crate) rows: u64,
-    pub(crate) timezone: Tz,
+    pub columns: Vec<BlockColumn>,
+    pub rows: u64,
+    pub timezone: Tz,
 }
 
 impl ServerBlock {

--- a/crates/client/src/protocol/column.rs
+++ b/crates/client/src/protocol/column.rs
@@ -71,6 +71,13 @@ pub struct ValueRef<'a> {
     // TODO: remove one level of indirection. Combine ValueRef and ValueRefEnum into single struct
     inner: Option<ValueRefEnum<'a>>,
 }
+
+impl<'a> ValueRef<'a> {
+    pub fn into_inner(self) -> Option<ValueRefEnum<'a>> {
+        self.inner
+    }
+}
+
 /// Implement SqlType::DateTime,SqlType::DateTime64-> chrono::DateTime<Utc> data conversion
 impl<'a> Value<'a, DateTime<Utc>> for ValueRef<'a> {
     fn get(&'a self, field: &'a Field) -> Result<Option<DateTime<Utc>>> {

--- a/crates/client/src/types/mod.rs
+++ b/crates/client/src/types/mod.rs
@@ -63,7 +63,7 @@ pub const FIELD_LOWCARDINALITY: u8 = 0x02;
 pub const FIELD_ARRAY: u8 = 0x04;
 
 pub struct Field {
-    pub(crate) sql_type: SqlType,
+    pub sql_type: SqlType,
     pub(crate) flag: u8,
     pub(crate) depth: u8,
     meta: Option<FieldMeta>,

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 base = { path = "../base" }
 lang = { path = "../lang" }
 meta = { path = "../meta" }
+client = { path = "../client" }
 typed-arena = "2.0"
 thiserror = "1.0"
 indexmap = "1.6"

--- a/crates/engine/src/errs.rs
+++ b/crates/engine/src/errs.rs
@@ -39,4 +39,7 @@ pub enum EngineError {
 
     #[error(transparent)]
     WrappingIOError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    WrappingClientError(#[from] client::prelude::errors::Error),
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -8,6 +8,7 @@ use types::QueryState;
 
 pub mod datafusions;
 pub mod errs;
+pub mod remote;
 pub mod types;
 
 pub fn run(

--- a/crates/engine/src/remote.rs
+++ b/crates/engine/src/remote.rs
@@ -1,0 +1,26 @@
+use crate::errs::EngineResult;
+use client::prelude::{Pool, ServerBlock};
+use std::lazy::SyncLazy;
+use tokio::runtime::{self, Runtime};
+
+static TOKIO_RT: SyncLazy<Runtime> = SyncLazy::new(|| {
+    runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap()
+});
+
+pub fn run(pool: &Pool, sql: &str) -> EngineResult<Vec<ServerBlock>> {
+    TOKIO_RT.block_on(async move {
+        let mut conn = pool.connection().await?;
+        let mut query_result = conn.query(sql).await?;
+        let mut blocks = vec![];
+
+        while let Some(block) = query_result.next().await? {
+            blocks.push(block);
+        }
+
+        Ok(blocks)
+    })
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -20,6 +20,7 @@ meta = { path = "../meta" }
 lang = { path = "../lang" }
 engine = { path = "../engine" }
 lightjit = { path = "../lightjit" }
+client = { path = "../client" }
 baselog = { git = "https://github.com/tensorbase/baselog.git", branch = "main" }
 clickhouse-rs-cityhash-sys = "0.1.2"
 arrow = { path = "../arrow" }

--- a/crates/runtime/src/errs.rs
+++ b/crates/runtime/src/errs.rs
@@ -151,6 +151,9 @@ pub enum BaseRtError {
 
     #[error(transparent)]
     WrappingArrowError(#[from] arrow::error::ArrowError),
+
+    #[error(transparent)]
+    WrappingClientError(#[from] client::prelude::errors::Error),
 }
 
 impl BaseRtError {
@@ -166,6 +169,7 @@ impl BaseRtError {
             BaseRtError::WrappingEngineError(_) => 7,
             BaseRtError::WrappingBaseError(_) => 8,
             BaseRtError::WrappingArrowError(_) => 9,
+            BaseRtError::WrappingClientError(_) => 10,
 
             BaseRtError::UnsupportedClientMessage => 21,
             BaseRtError::UnsupportedClientVersion => 22,

--- a/crates/runtime/src/read.rs
+++ b/crates/runtime/src/read.rs
@@ -1,9 +1,14 @@
+use crate::{
+    ch::blocks::Block,
+    errs::{BaseRtError, BaseRtResult},
+    mgmt::BMS,
+};
+use client::prelude::{errors::Error as ClientError, PoolBuilder};
+use engine::remote;
 use engine::types::QueryState;
-use lang::parse::{Pair, Rule};
+use lang::parse::{Pair, RemoteAddr, RemoteTableInfo, Rule};
 use meta::store::{parts::PartStore, sys::MetaStore};
 use std::{convert::TryFrom, time::Instant};
-
-use crate::{ch::blocks::Block, errs::BaseRtResult};
 
 pub fn query(
     ms: &MetaStore,
@@ -38,6 +43,88 @@ pub fn query(
         log::debug!("blk: {:?}", blk);
         blks.push(blk);
     }
+
+    Ok(blks)
+}
+
+const DEFAULT_REMOTE_PORT: u16 = 9528;
+const DEFAULT_REMOTE_COMPRESSION: &str = "lz4";
+const DEFAULT_REMOTE_POOL_MIN_SIZE: u16 = 1;
+const DEFAULT_REMOTE_POOL_MAX_SIZE: u16 = 4;
+
+fn update_remote_db_pools(remote_tb_info: &RemoteTableInfo) -> BaseRtResult<()> {
+    let ps = &BMS.remote_db_pool;
+
+    let RemoteTableInfo {
+        addrs,
+        username,
+        password,
+        database_name,
+        table_name,
+    } = remote_tb_info;
+    for remote_addr in addrs {
+        if let Some(pool) = ps.get(&remote_addr) {
+            continue;
+        }
+
+        let RemoteAddr {
+            ip_addr,
+            host_name,
+            port,
+        } = remote_addr.clone();
+        let mut builder = PoolBuilder::default()
+            .with_compression()
+            .with_pool(DEFAULT_REMOTE_POOL_MIN_SIZE, DEFAULT_REMOTE_POOL_MAX_SIZE);
+
+        if let Some(username) = &username {
+            builder = builder.with_username(username);
+        }
+
+        if let Some(password) = &password {
+            builder = builder.with_password(password);
+        }
+
+        if let Some(database) = &database_name {
+            builder = builder.with_database(database);
+        }
+
+        let addr = ip_addr
+            .map(|i| i.to_string())
+            .or(host_name)
+            .map(|s| format!("{}:{}", s, port.unwrap_or(DEFAULT_REMOTE_PORT)))
+            .unwrap_or("".into());
+
+        builder = builder.add_addr(addr);
+        let pool = builder.build()?;
+        ps.insert(remote_addr.clone(), pool);
+    }
+
+    Ok(())
+}
+
+pub fn remote_query(
+    remote_tb_info: RemoteTableInfo,
+    raw_query: &str,
+) -> BaseRtResult<Vec<Block>> {
+    let ps = &BMS.remote_db_pool;
+    update_remote_db_pools(&remote_tb_info)?;
+    let sql = remote_tb_info
+        .to_local_query_str(raw_query)
+        .ok_or(ClientError::Other("missing table info.".into()))?;
+    let blks = remote_tb_info
+        .addrs
+        .into_iter()
+        .map(|addr| {
+            let pool = &*ps.get(&addr).unwrap();
+            match remote::run(pool, &sql) {
+                Ok(blks) => Ok(blks.into_iter().map(|b| b.into())),
+                Err(err) => Err(BaseRtError::WrappingEngineError(err)),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect();
 
     Ok(blks)
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -9,8 +9,8 @@ use baselog::{ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 use bytes::BytesMut;
 use log::info;
 use runtime::{
-    mgmt::{BMS, READ, WRITE},
-    read::query,
+    mgmt::{BMS, READ, REMOTE_READ, WRITE},
+    read::{query, remote_query},
     write::write_block,
 };
 use server::BaseSrvConn;
@@ -56,6 +56,7 @@ async fn main() -> io::Result<()> {
     //init
     READ.get_or_init(|| query);
     WRITE.get_or_init(|| write_block);
+    REMOTE_READ.get_or_init(|| remote_query);
 
     // start http server
     Server::build()

--- a/crates/server/tests/confs/base.conf
+++ b/crates/server/tests/confs/base.conf
@@ -1,4 +1,5 @@
 [system]
+
 meta_dirs = ["/tmp/tb_schema"]
 data_dirs = ["/tmp/tb_data"]
 


### PR DESCRIPTION
Related #109 let it work first，and we need more optimization, for example, the best approach is to unify the server and client block definitions to avoid conversions. 
We can support `insert into select a from remote('127.0.0.1:9000', test_a) limit 10` now to insert remote data, then we can support `insert into Function remote`  semantic next step.
Signed-off-by: pandaplusplus <pandaplusplus@gmail.com>