### PR TITLE
REFACTOR(parse, storage):  support basic partition prune

### DIFF
--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -19,6 +19,7 @@ chrono-tz = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 rand = "0.8"
+fasteval = "0.2.4"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/base/src/errs.rs
+++ b/crates/base/src/errs.rs
@@ -43,4 +43,7 @@ pub enum BaseError {
 
     #[error("Encoding too long string")]
     EncodingTooLongString,
+
+    #[error("Can not be evaluted")]
+    CanotEval,
 }

--- a/crates/base/src/eval.rs
+++ b/crates/base/src/eval.rs
@@ -1,0 +1,53 @@
+use std::cell::RefCell;
+
+use fasteval::EmptyNamespace;
+use fasteval::Evaler;
+use fasteval::Parser;
+use fasteval::Slab;
+
+use crate::errs::BaseError;
+use crate::errs::BaseResult;
+
+const PARSER: Parser = Parser::new();
+thread_local! {
+    static SLAB: RefCell<Slab> = RefCell::new(Slab::new());
+}
+
+pub fn eval_literal_u64(expr: &str) -> BaseResult<u64> {
+    eval_literal(expr).map(|e| e as u64)
+}
+
+pub fn eval_literal(expr: &str) -> BaseResult<f64> {
+    SLAB.with(|slab| {
+        let mut sm = slab.borrow_mut();
+        let expr_ref = PARSER
+            .parse(expr, &mut sm.ps)
+            .map_err(|_e| BaseError::CanotEval)?
+            .from(&sm.ps);
+        let rt = expr_ref.eval(&sm, &mut EmptyNamespace);
+        rt.map_err(|_e| BaseError::CanotEval)
+    })
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn basic_check() -> BaseResult<()> {
+        assert_eq!(25.0, eval_literal("2.5*10")?);
+        assert_eq!(123, eval_literal_u64("0.123*1000")?);
+        Ok(())
+    }
+
+    #[test]
+    fn stress_eval_literal() {
+        let chks = [25, 123, 365, 222];
+        let exps = ["2.5*10", "0.123*1000", "365*1", "888-666"];
+        for _ in 0..10000 {
+            for (i, e) in exps.iter().enumerate() {
+                assert_eq!(chks[i], eval_literal_u64(e).unwrap());
+            }
+        }
+    }
+}

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -35,5 +35,6 @@ pub mod mem;
 pub mod mmap;
 pub mod strings;
 pub mod utils;
+pub mod eval;
 
 pub use base_proc_macro::async_test;

--- a/crates/engine/tests/df_tests.rs
+++ b/crates/engine/tests/df_tests.rs
@@ -77,7 +77,7 @@ fn init_copas2(cis: Vec<(Id, BqlType)>) -> Vec<Vec<CoPaInfo>> {
     let ps = PartStore::new(&[parts_dir], dd).unwrap();
     // ps.pretty_print().unwrap();
     let mut copas = Vec::new();
-    ps.fill_copainfos_int_by_ptk_range(&mut copas, TID, &cis, 0, u64::MAX)
+    ps.fill_copainfos_int_by_ptk_range(&mut copas, TID, &cis, vec![0..=u64::MAX])
         .unwrap();
     copas
 }

--- a/crates/lang/src/bql.pest
+++ b/crates/lang/src/bql.pest
@@ -288,11 +288,11 @@ logical_val  = {
 or_logical_val = { les_or_op ~ logical_val }
 and_logical_val = { les_and_op ~ logical_val }
 or_logical_expr = {
-    logical_val ~  ( or_logical_val )+ |
+    logical_val ~  ( or_logical_val )* |
     "(" ~ logical_val ~  ( or_logical_val )+ ~ ")"
 }
 and_logical_expr = { 
-    logical_val ~  ( and_logical_val )+ | 
+    logical_val ~  ( and_logical_val )* | 
     "(" ~ logical_val ~  ( and_logical_val )+ ~ ")"
 }
 
@@ -307,7 +307,6 @@ or_logical_exprs_with_and = {
 logical_expr = {
     and_logical_exprs_with_or |
     or_logical_exprs_with_and |
-    logical_val | 
     "(" ~ logical_expr ~ ")"
 }
 

--- a/crates/lang/src/errs.rs
+++ b/crates/lang/src/errs.rs
@@ -26,6 +26,9 @@ pub enum LangError {
     WrappingMetaError(#[from] meta::errs::MetaError),
 
     #[error(transparent)]
+    WrappingBaseError(#[from] base::errs::BaseError),
+
+    #[error(transparent)]
     WrappingParseIntError(#[from] ParseIntError),
 
     #[error(transparent)]
@@ -48,4 +51,10 @@ pub enum LangError {
 
     #[error("Fail to unwrap")]
     FailToUnwrap,
+
+    #[error("Unsupported partition key expr parsing")]
+    PartitionKeyExprParsingUnsupported,
+
+    #[error("Conflict condition when partition key pxpr parsing")]
+    PartitionKeyExprParsingConflict,
 }

--- a/crates/meta/src/store/sys.rs
+++ b/crates/meta/src/store/sys.rs
@@ -306,9 +306,9 @@ impl MetaStore {
 
     pub fn get_columns_by_qtn(
         &self,
-        qtn: &String,
+        qtn: &str,
     ) -> MetaResult<Vec<(String, u64, ColumnInfo)>> {
-        let cnp = to_qualified_key!(qtn.as_str(), "");
+        let cnp = to_qualified_key!(qtn, "");
         self._get_columns(&cnp)
     }
 

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -806,7 +806,7 @@ impl<'a> BaseMgmtSys<'a> {
         }
         let p = ps.remove(0);
         log::debug!("successfully parsed command: {} ", cmds);
-        let p = seek_to_sub_cmd(&mut p.into_inner())
+        let p = seek_to_sub_cmd(p.into_inner())
             .map_err(|e| BaseRtError::WrappingLangError(e))?;
         Ok(p)
     }


### PR DESCRIPTION
Signed-off-by: nautaa <870284156@qq.com>
I am not sure if there is still a problem with the implementation.
* not support `datetime` prune yet.
* only support easy partition prune base on values.
relate issue: #55 