### PR TITLE
FEAT(platform): Add MacOS support

### DIFF
--- a/crates/base/src/mmap.rs
+++ b/crates/base/src/mmap.rs
@@ -24,16 +24,6 @@ pub fn mm_anon(size: usize) -> BaseResult<MemAddr> {
 }
 
 #[inline]
-pub fn mm_mremap(addr: MemAddr, old_size: usize, new_size: usize) -> BaseResult<MemAddr> {
-    let ret = unsafe { libc::mremap(addr, old_size, new_size, libc::MREMAP_MAYMOVE) };
-    if addr == libc::MAP_FAILED {
-        Err(BaseError::FailedToMremap)
-    } else {
-        Ok(ret)
-    }
-}
-
-#[inline]
 pub fn mm_file_ro(fd: u32, size: usize) -> BaseResult<MemAddr> {
     let addr = unsafe {
         libc::mmap(

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -17,6 +17,9 @@ use meta::{
     types::{BqlType, Id},
 };
 
+#[cfg(target_os = "macos")]
+use libc::fstore_t;
+
 use crate::{
     ch::blocks::Block,
     errs::{BaseRtError, BaseRtResult},
@@ -299,9 +302,35 @@ fn write_part(
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+#[inline(always)]
+unsafe fn fallocate(fd: i32, mode: i32, offset_in_bytes: i64, pt_len_in_bytes: i64) -> bool {
+    // https://stackoverflow.com/questions/11497567/fallocate-command-equivalent-in-os-x
+    let store = fstore_t {
+        fst_flags: libc::F_ALLOCATECONTIG | libc::F_ALLOCATEALL,
+        fst_posmode: libc::F_PEOFPOSMODE,
+        fst_offset: offset_in_bytes,
+        fst_length: pt_len_in_bytes,
+        fst_bytesalloc: 0
+    };
+
+    libc::fcntl(fd, libc::F_PREALLOCATE, &store as *const fstore_t) == 0
+}
+
+#[cfg(target_os = "linux")]
+#[inline(always)]
+unsafe fn fallocate(fd: i32, mode: i32, offset_in_bytes: i64, pt_len_in_bytes: i64) -> bool {
+    libc::fallocate(
+        fd,
+        mode,
+        offset_in_bytes,
+        pt_len_in_bytes
+    ) == 0
+}
+
 fn dump_buf(fd: u32, offset_in_bytes: usize, pt_len_in_bytes: usize, buf: *const c_void) {
     unsafe {
-        libc::fallocate(fd as i32, 0, offset_in_bytes as i64, pt_len_in_bytes as i64);
+        fallocate(fd as i32, 0, offset_in_bytes as i64, pt_len_in_bytes as i64);
         libc::pwrite(fd as i32, buf, pt_len_in_bytes, offset_in_bytes as i64);
         close(fd as i32);
     }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -22,10 +22,14 @@ pub fn prepare_empty_tmp_dir(dir: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use crate::prepare_empty_tmp_dir;
+    use std::env::temp_dir;
 
     #[test]
     fn test_prepare_empty_tmp_dir() {
-        assert_eq!(prepare_empty_tmp_dir(None), "/tmp/base_test".to_string());
+        assert_eq!(
+            prepare_empty_tmp_dir(None),
+            [temp_dir().to_str().unwrap(), "base_test"].join("/")
+        );
         assert_eq!(
             prepare_empty_tmp_dir(Some("/tmp/base_test2")),
             "/tmp/base_test2".to_string()


### PR DESCRIPTION
Hi all!

I'm using MacOS for development, so I tried to port Tensorbase to MacOS . I've managed to pass all the unit tests on my MacOS 10.15.7. It turns out that not too many changes are needed and they are mostly due to libc API incompatibilities. 

Three files are changed:

- mmap.rs: I removed m_mremap() function because MacOS doesn't have mremap() system call. This function is in fact dead code so removing it does not have any impact.
- part.rs: MacOS's open() call doesn't have the `mode` argument , so I used chmod() to change the file's access mode after file opening. The `O_NOATIME` flag is not present in MacOS, so I just removed it. **I'm not sure if this will cause any side effects.**
- write.rs: MacOS doesn't have the falllocate() system call. I wrote a custom fallocate() function using fcntl() based on [this](https://stackoverflow.com/questions/11497567/fallocate-command-equivalent-in-os-x) Stack Overflow answer.

I also changed one unit test. On my MacOS the temporary directory is in `/var/folders/69/n3mc_xcd1zj1mf898dhkdf3m0000gp/T/` instead of `/tmp/`, so I think we should use `temp_dir()` to return the temp dir address instead of using hardcoded `/tmp/`.

I noticed this [issue](https://github.com/tensorbase/tensorbase/issues/80) that states that we don't have enough resource for support of other platforms. What exact resource do we need? Are there anything I could help?