### PR TITLE
FIX(lang):should use all partitions if partition expr isn't hit

### DIFF
--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -657,6 +657,8 @@ pub fn parse_where(
         Ok(_) => {
             if ctx.ptk_ranges.iter().any(|r| r.start() > r.end()) {
                 Ok(vec![])
+            } else if ctx.ptk_ranges.len() == 0 {
+                Ok(vec![0..=u64::MAX])
             } else {
                 Ok(ctx.ptk_ranges)
             }
@@ -1820,7 +1822,7 @@ CREATE TABLE test (col Int32)";
             let r = parse_where(c, "toYear(a)").unwrap();
             assert_eq!(
                 r.into_iter().collect::<HashSet<_>>(),
-                vec![].into_iter().collect::<HashSet<_>>()
+                vec![0..=u64::MAX].into_iter().collect::<HashSet<_>>()
             );
 
             let c = "where toYYYY(pickup_datetime)=1970";

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -1118,6 +1118,38 @@ async fn tests_integ_select_all() -> errors::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn tests_integ_partition_prune() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists test1_tab"))
+        .await?;
+    conn.execute(format!(
+        "create table test1_tab(a UInt64, b UInt64) engine=BaseStorage partition by a"
+    ))
+    .await?;
+    conn.execute(format!("insert into test1_tab values(1,1),(2,2)"))
+        .await?;
+
+    {
+        let sql = "select a from test1_tab where b = 1";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
 // #[tokio::test]
 // async fn test_insert_large_block() -> errors::Result<()> {
 //     let pool = get_pool();


### PR DESCRIPTION
Signed-off-by: nautaa <870284156@qq.com>
if there is no hit partition key in parse where condition, we should use all partitions.
wrong case:
```
create table t (a UInt32, b UInt32)engine=BaseStorage partition by a
insert into t values (1,1),(2,2)
TensorBase :) select a from t where b = 1

SELECT a
FROM t
WHERE b = 1

Query id: 7803f9da-c4e3-4dae-bebd-4db4a0de3939

Ok.

0 rows in set. Elapsed: 0.005 sec. 
```