### PR TITLE
fix partition prune

### DIFF
--- a/crates/engine/src/datafusions.rs
+++ b/crates/engine/src/datafusions.rs
@@ -162,19 +162,20 @@ pub(crate) fn run(
         let copasss = &mut qs.copasss;
         let mut copass = Vec::new();
         ps.fill_copainfos_int_by_ptk_range(&mut copass, tid, &cis, ptk_range)?;
-        if copass.len() == 0 {
-            return Err(EngineError::UnexpectedDataLoadingError);
+        if copass.len() > 0 {
+            log::debug!(
+                "got {} copas, with {} copa per copas for {}",
+                copass.len(),
+                copass[0].len(),
+                tid,
+            );
+            setup_tables(tab, schema, &mut ctx, &cis, &copass)?;
+            copasss.push(copass);
         }
-        log::debug!(
-            "got {} copas, with {} copa per copas for {}",
-            copass.len(),
-            copass[0].len(),
-            tid,
-        );
-
-        setup_tables(tab, schema, &mut ctx, &cis, &copass)?;
-
-        copasss.push(copass);
+    }
+    if qs.copasss.len() == 0 {
+        let res: Vec<RecordBatch> = Vec::new();
+        return Ok(res);
     }
     // log::info!("query setup runtime(ms): {}", t.elapsed().as_millis());
 

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -541,7 +541,7 @@ impl<'a> ParseWhereContext<'a> {
                                         }
                                     }
                                 },
-                                "<>" => match self.ptk_ranges.len() {
+                                op @ "<>" | op @ "!=" => match self.ptk_ranges.len() {
                                     0 => {
                                         self.ptk_ranges.push(0..=p - 1);
                                         self.ptk_ranges.push(p + 1..=u64::MAX);

--- a/crates/meta/src/store/parts.rs
+++ b/crates/meta/src/store/parts.rs
@@ -360,7 +360,6 @@ impl<'a> PartStore<'a> {
         for res in it {
             if let Ok((kbs, _v)) = res {
                 let (_, ptk_be) = *(&*kbs).into_ref::<(u64, u64)>();
-                //
                 let k = (tid.to_be(), ptk_be);
                 let kbs = k.as_bytes();
                 let ptk = ptk_be.to_be();
@@ -398,7 +397,9 @@ impl<'a> PartStore<'a> {
                 return Err(MetaError::GetPartInfoError);
             }
         }
-        copass_ret.push(cps);
+        if cps.len() > 0 {
+            copass_ret.push(cps);
+        }
         Ok(())
     }
 

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -829,8 +829,7 @@ async fn tests_integ_select_remote_function() -> errors::Result<()> {
     let data_i = vec!["abc", "efg", "hello world"];
 
     {
-        let sql =
-            "select a,b,c,d,i,j from remote('127.0.0.1:9528', test_remote_func)";
+        let sql = "select a,b,c,d,i,j from remote('127.0.0.1:9528', test_remote_func)";
         let mut query_result = conn.query(sql).await?;
 
         while let Some(block) = query_result.next().await? {
@@ -1162,7 +1161,7 @@ async fn tests_integ_partition_prune() -> errors::Result<()> {
 
         while let Some(block) = query_result.next().await? {
             let cnt = block.row_count();
-            println!("cnt:{}",cnt);
+            println!("cnt:{}", cnt);
             assert_eq!(cnt, 1);
         }
     }

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -819,17 +819,18 @@ async fn tests_integ_select_remote_function() -> errors::Result<()> {
     insert.commit().await?;
 
     drop(insert);
-    let dates = [
-        Utc.ymd(2010, 1, 1).and_hms(0, 0, 0),
-        Utc.ymd(2011, 2, 28).and_hms(0, 0, 0),
-        Utc.ymd(2012, 2, 29).and_hms(0, 0, 0),
+    let dates = vec![
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+        NaiveDate::from_ymd(2011, 2, 28).and_hms(2, 5, 6),
+        NaiveDate::from_ymd(2012, 2, 29).and_hms(23, 59, 59),
     ];
+    let dates = apply_offset(&dates, FixedOffset::west(11 * 3600 + 45 * 60));
     let data = vec![1, 2, 3];
     let data_i = vec!["abc", "efg", "hello world"];
 
     {
         let sql =
-            "select a,b,c,d,e,f,h,i,j from remote('127.0.0.1:9528', test_remote_func)";
+            "select a,b,c,d,i,j from remote('127.0.0.1:9528', test_remote_func)";
         let mut query_result = conn.query(sql).await?;
 
         while let Some(block) = query_result.next().await? {

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -1153,10 +1153,10 @@ async fn tests_integ_partition_prune() -> errors::Result<()> {
     ))
     .await?;
 
-    conn.execute(format!("insert into test1_tab values(1,1),(2,2)"))
+    conn.execute(format!("insert into test2_tab values(1,1),(2,2)"))
         .await?;
     {
-        let sql = "select * from test2_tab where toYear(a)<>1";
+        let sql = "select * from test2_tab where a<>1";
         let mut query_result = conn.query(sql).await?;
 
         while let Some(block) = query_result.next().await? {


### PR DESCRIPTION
wrong case:
```
create table t (a DateTime, b UInt32) engine=BaseStorage partition by toYear(a)
insert into t values ('2020-01-01:08:00:00',1),('2021-01-01:08:00:00',1)
TensorBase :) select * from t where toYear(a)<>2020
SELECT *
FROM t
WHERE toYear(a) != 2020

Query id: d986e108-ea6a-42dc-8d18-3f261fa6e516

Ok.

0 rows in set. Elapsed: 6.991 sec.
```
also fix a related test case in `integ_test`.
