### PR TITLE
[DOCS] update get started docs

### DIFF
--- a/docs/get_started_developers.md
+++ b/docs/get_started_developers.md
@@ -38,12 +38,12 @@ The development of TensorBase is same to the idiom of Rust engineering.
 
 5. connect to the TensorBase server with clickhouse-client like this:
 
-        clickhouse-client --port 9528 -n
-        
+        ```clickhouse-client --port 9528``` or ```clickhouse-client --port 9528 -n```
+    
     NOTE:
 
     `--port` – Here 9528 is the default port of TensorBase.
-    `--multiquery`, `-n` – If specified, allow processing multiple queries separated by semicolons.
+    `--multiquery`, `-n` – If specified, allow processing multiple queries separated by semicolons. (So, it may be slightly quicker than multiple statements.)
 
 6. execute query like this:
 

--- a/docs/get_started_developers.md
+++ b/docs/get_started_developers.md
@@ -38,16 +38,21 @@ The development of TensorBase is same to the idiom of Rust engineering.
 
 5. connect to the TensorBase server with clickhouse-client like this:
 
-        clickhouse-client --port 9528
+        clickhouse-client --port 9528 -n
         
-    NOTE: here 9528 is the default port of TensorBase
+    NOTE:
+
+    `--port` – Here 9528 is the default port of TensorBase.
+    `--multiquery`, `-n` – If specified, allow processing multiple queries separated by semicolons.
 
 6. execute query like this:
 
-        create table employees (id UInt64, salary UInt64) ENGINE = BaseStorage
-        insert into employees values (0, 1000), (1, 1500)
-        select count(id) from employees
-        select avg(salary) from employees
+        ```sql
+        create table employees (id UInt64, salary UInt64) ENGINE = BaseStorage;
+        insert into employees values (0, 1000), (1, 1500);
+        select count(id) from employees;
+        select avg(salary) from employees;
+        ```
 
 7. more supported statements could be seen [here](/docs/lang.md).
 

--- a/docs/get_started_users.md
+++ b/docs/get_started_users.md
@@ -21,13 +21,13 @@
         ./server -c $path_to_base_conf$
 
 4. connect to the TensorBase server with clickhouse-client like this:
-
-        clickhouse-client --port 9528 -n
+        
+        ```clickhouse-client --port 9528``` or ```clickhouse-client --port 9528 -n```
     
     NOTE:
 
     `--port` – Here 9528 is the default port of TensorBase.
-    `--multiquery`, `-n` – If specified, allow processing multiple queries separated by semicolons.
+    `--multiquery`, `-n` – If specified, allow processing multiple queries separated by semicolons. (So, it may be slightly quicker than multiple statements.)
 
 5. execute query like this:
 

--- a/docs/get_started_users.md
+++ b/docs/get_started_users.md
@@ -22,16 +22,21 @@
 
 4. connect to the TensorBase server with clickhouse-client like this:
 
-        clickhouse-client --port 9528
+        clickhouse-client --port 9528 -n
     
-    NOTE: here 9528 is the default port of TensorBase
+    NOTE:
+
+    `--port` – Here 9528 is the default port of TensorBase.
+    `--multiquery`, `-n` – If specified, allow processing multiple queries separated by semicolons.
 
 5. execute query like this:
 
-        create table employees (id UInt64, salary UInt64) ENGINE = BaseStorage
-        insert into employees values (0, 1000), (1, 1500)
-        select count(id) from employees
-        select avg(salary) from employees
+        ```sql
+        create table employees (id UInt64, salary UInt64) ENGINE = BaseStorage;
+        insert into employees values (0, 1000), (1, 1500);
+        select count(id) from employees;
+        select avg(salary) from employees;
+        ```
 
 6. more supported statements could be seen [here](/docs/lang.md)
 


### PR DESCRIPTION
I tried to make TensorBase support the execution of multiple SQL statements, and finally found that clickhouse-client only needs to set a parameter -n.
So I modified the get_started docs. 
I think maybe users should be more accustomed to executing multiple SQL statements with ";".
It should be safe to do so, because #107 has already been completed.