### PR TITLE
REFACTOR(lang): support or expr, between ... and ... expr

### DIFF
--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -2114,6 +2114,13 @@ CREATE TABLE test (col Int32)";
                 r.into_iter().collect::<HashSet<_>>(),
                 vec![1..=1, 10..=10].into_iter().collect::<HashSet<_>>()
             );
+
+            let c = "where a=10 or a=100 or a!=100";
+            let r = parse_where(c, "a").unwrap();
+            assert_eq!(
+                r.into_iter().collect::<HashSet<_>>(),
+                vec![0..=u64::MAX].into_iter().collect::<HashSet<_>>()
+            );
         }
 
         #[test]


### PR DESCRIPTION
Signed-off-by: nautaa <870284156@qq.com>
* Basically support `or` expr. And this will not deal with `or` `and` mixed situations at this time, in other words, multi-levels logical state.
* Basically support `between and` expr.
* add some unit tests for changes.