### PR TITLE
FEAT(lang,client,lang,runtime,integ_tests) insert into remote related #109

### DIFF
--- a/.github/workflows/base_checks.yml
+++ b/.github/workflows/base_checks.yml
@@ -25,4 +25,4 @@ jobs:
     - name: TensorBase Build
       run: cargo build
     - name: TensorBase unit tests
-      run: cargo test --exclude 'arrow*' --exclude datafusion --exclude 'ballista*' --exclude parquet --workspace -- --test-threads=1 --skip tests_integ
+      run: cargo test --exclude 'server_mysql' --exclude 'arrow*' --exclude datafusion --exclude 'ballista*' --exclude parquet --workspace -- --test-threads=1 --skip tests_integ

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -30,7 +30,6 @@ byteorder = "^1.3"
 [features]
 tls = ["tokio-native-tls"]
 int128 = []
-
 extra = []
 
 # [[example]]

--- a/crates/client/src/protocol/column.rs
+++ b/crates/client/src/protocol/column.rs
@@ -49,6 +49,9 @@ pub trait AsOutColumn {
 pub trait AsInColumn: Send {
     unsafe fn get_at(&self, index: u64) -> ValueRef<'_>;
     unsafe fn into_bytes(&mut self) -> Vec<u8>;
+    fn offset_map(&self) -> Option<Vec<u32>> {
+        None
+    }
 }
 
 /// Default implementation returns `Null` data
@@ -644,6 +647,19 @@ impl<'a> AsInColumn for FixedColumn<BoxString> {
             })
             .flatten()
             .collect()
+    }
+
+    fn offset_map(&self) -> Option<Vec<u32>> {
+        let mut offset = vec![0];
+        let mut start = 0;
+
+        offset = self.data.iter().fold(offset, |mut offset, s| {
+            start = s.len() + start + 1;
+            offset.push(start as u32);
+            offset
+        });
+
+        Some(offset)
     }
 }
 

--- a/crates/lang/src/bql.pest
+++ b/crates/lang/src/bql.pest
@@ -77,12 +77,11 @@ use_db = { ^"use" ~ database_name }
 
 //insert
 insert_into = { 
-    ^"insert" ~ ^"into" ~ 
-    qualified_table_name ~  
-    column_list? ~ 
-    format_clause? ~
-    select?
- }
+    ^"insert" ~ ^"into" ~
+    ((^"function" ~ select_remote) |
+	(qualified_table_name ~ column_list? ~ format_clause? ~ select?))
+}
+
 column_list = { "(" ~ column_name ~ ( "," ~ column_name )* ~ ")" }
 format_clause = {
     ^"values" ~ rows* |
@@ -129,6 +128,7 @@ ipv6_lit = @{
 }
 
 from = { ^"from" ~ ( remote_func | join_tables | compound_select ) }
+select_remote = {remote_func ~ (select | ("values" ~ rows*)) }
 
 remote_func = {
     ^"remote" ~ "(" ~ remote_addresses ~ "," ~ remote_table ~ ("," ~ username_lit ~ "," ~ password_lit)? ~ ")"

--- a/crates/runtime/src/ch/blocks.rs
+++ b/crates/runtime/src/ch/blocks.rs
@@ -230,13 +230,14 @@ impl From<ServerBlock> for Block {
 
         for mut c in b.columns {
             let btype = sqltype_to_bqltype(c.header.field.get_sqltype());
+            let offset_map = c.data.offset_map();
             let data = unsafe { c.data.into_bytes() };
             let chunk = BaseChunk {
                 btype,
                 size: nrows,
                 data,
                 null_map: None,
-                offset_map: None,
+                offset_map,
                 lc_dict_data: None,
             };
             let column = Column {

--- a/crates/runtime/src/read.rs
+++ b/crates/runtime/src/read.rs
@@ -132,6 +132,5 @@ pub fn remote_query(
         .flatten()
         .collect();
 
-
     Ok(blks)
 }

--- a/crates/runtime/src/read.rs
+++ b/crates/runtime/src/read.rs
@@ -105,12 +105,18 @@ fn update_remote_db_pools(remote_tb_info: &RemoteTableInfo) -> BaseRtResult<()> 
 pub fn remote_query(
     remote_tb_info: RemoteTableInfo,
     raw_query: &str,
+    is_local: bool,
 ) -> BaseRtResult<Vec<Block>> {
     let ps = &BMS.remote_db_pool;
     update_remote_db_pools(&remote_tb_info)?;
-    let sql = remote_tb_info
-        .to_local_query_str(raw_query)
-        .ok_or(ClientError::Other("missing table info.".into()))?;
+
+    let sql = if !is_local {
+        remote_tb_info
+            .to_local_query_str(raw_query)
+            .ok_or(ClientError::Other("missing table info.".into()))?
+    } else {
+        raw_query.to_owned()
+    };
     let blks = remote_tb_info
         .addrs
         .into_iter()
@@ -125,6 +131,7 @@ pub fn remote_query(
         .into_iter()
         .flatten()
         .collect();
+
 
     Ok(blks)
 }

--- a/crates/server_mysql/Cargo.toml
+++ b/crates/server_mysql/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = "0.1.40"
 rand = "0.8.3"
 
 [dev-dependencies]
-postgres = "0.15"
+postgres = "0.19.1"
 mysql = "18"
 mysql_async = "0.20.0"
 slab = "0.4.2"


### PR DESCRIPTION
FEAT(lang,client,lang,runtiem,integ_tests)` insert into remote 'FUNCTION' keyword support

Signed-off-by: pandaplusplus <pandaplusplus@gmail.com>