### PR TITLE
feat: support column default expr when insert from ch driver

### DIFF
--- a/crates/lang/src/bql.pest
+++ b/crates/lang/src/bql.pest
@@ -33,12 +33,14 @@ create_table = {
 }
 if_not_exists = { ^"if" ~ ^"not" ~ ^"exists" }
 column_def = {
-    column_name ~ type_name ~ column_constraint?
+    column_name ~ type_name ~ column_default_value? ~ column_constraint?
 }
 column_constraint = {
     ^"primary" ~ ^"key" ~ sort_order? |
-    ^"not" ~ ^"null" |
-    ^"default" ~ literal
+    ^"not" ~ ^"null" 
+}
+column_default_value = {
+     ^"default" ~ arith_expr
 }
 table_attributes = {
     table_attr_engine? ~ 

--- a/crates/runtime/src/errs.rs
+++ b/crates/runtime/src/errs.rs
@@ -42,6 +42,9 @@ pub enum BaseRtError {
     #[error("Unsupported partition key type")]
     UnsupportedPartitionKeyType,
 
+    #[error("Unsupported default expression argment type")]
+    UnsupportedDefaultExpressionArgumentType,
+
     #[error("Command parsing error")]
     CommandParsingError,
 
@@ -180,6 +183,7 @@ impl BaseRtError {
             BaseRtError::UnsupportedLowCardinalityDictVersion => 27,
             BaseRtError::UnsupportedPartitionKeyType => 28,
             BaseRtError::UnsupportedConversionToBqlType => 29,
+            BaseRtError::UnsupportedDefaultExpressionArgumentType => 30,
 
             BaseRtError::InvalidStringConversion(_) => 100,
             BaseRtError::IndexOutOfRange => 101,

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -424,8 +424,8 @@ mod unit_tests {
         mem::{shape_slice, shape_vec_u8},
         with_timer_print,
     };
-    use baselog::{Config, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
     use basejit::builtins::to_fn1;
+    use baselog::{Config, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
     use meta::{
         confs::Conf,
         types::{BaseChunk, BqlType, ColumnInfo, EngineType, Table, TableInfo},
@@ -506,6 +506,8 @@ mod unit_tests {
                         is_primary_key: true,
                         is_nullable: false,
                         ordinal: 0,
+                        default_expr: Default::default(),
+                        default_expr_cols: Default::default(),
                     },
                 ),
                 (
@@ -515,6 +517,8 @@ mod unit_tests {
                         is_primary_key: false,
                         is_nullable: false,
                         ordinal: 0,
+                        default_expr: Default::default(),
+                        default_expr_cols: Default::default(),
                     },
                 ),
             ],


### PR DESCRIPTION
Default expression support. #201 
1.  Column default expression could be specified when creating table.
2. TB will calculate and write the omit value  to storage when insert statement  specify some columns,  But it only supports for inner driver now. 