### PR TITLE
REFACTOR(runtime): make runtime independent of CH protocol 

### DIFF
--- a/crates/runtime/src/ch/protocol.rs
+++ b/crates/runtime/src/ch/protocol.rs
@@ -1,3 +1,4 @@
+use crate::types::BaseServerConn;
 use bytes::BytesMut;
 use meta::types::Id;
 
@@ -205,6 +206,32 @@ pub struct ConnCtx {
     pub data_block_opt: Option<Box<Block>>,
     pub raw_blk_req: Option<BytesMut>,
     raw_blk_resp: Option<BytesMut>,
+}
+
+impl BaseServerConn for ConnCtx {
+    fn get_query_id(&self) -> &str {
+        &self.query_id
+    }
+
+    fn set_query_id(&mut self, query_id: String) {
+        self.query_id = query_id;
+    }
+
+    fn get_db(&self) -> &str {
+        &self.current_db
+    }
+
+    fn set_db(&mut self, db: String) {
+        self.current_db = db;
+    }
+
+    fn set_compressed(&mut self, is_compressed: bool) {
+        self.is_compressed = is_compressed;
+    }
+
+    fn is_compressed(&self) -> bool {
+        self.is_compressed
+    }
 }
 
 impl Default for ConnCtx {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -5,4 +5,5 @@ pub mod ch;
 pub mod errs;
 pub mod mgmt;
 pub mod read;
+pub mod types;
 pub mod write;

--- a/crates/runtime/src/mysql/mod.rs
+++ b/crates/runtime/src/mysql/mod.rs
@@ -1,0 +1,306 @@
+extern crate server_mysql;
+
+use async_trait::async_trait;
+use std::io;
+use tokio::io::AsyncWrite;
+
+use arrow::{array, datatypes::DataType, record_batch::RecordBatch};
+use log;
+use server_mysql::{
+    AsyncMysqlShim, Column, ColumnFlags, ColumnType, ErrorKind, InitWriter, ParamParser,
+    QueryResultWriter, StatementMetaWriter,
+};
+
+use crate::{
+    errs::{BaseRtError, BaseRtResult},
+    mgmt::{BaseCommandKind, BMS},
+    types::BaseServerConn,
+};
+
+#[derive(Default, Debug)]
+pub struct MysqlConn {
+    query_id: String,
+    current_db: String,
+    is_compressed: bool,
+}
+
+impl BaseServerConn for MysqlConn {
+    fn get_query_id(&self) -> &str {
+        &self.query_id
+    }
+
+    fn set_query_id(&mut self, query_id: String) {
+        self.query_id = query_id;
+    }
+
+    fn get_db(&self) -> &str {
+        &self.current_db
+    }
+
+    fn set_db(&mut self, db: String) {
+        self.current_db = db;
+    }
+
+    fn set_compressed(&mut self, is_compressed: bool) {
+        self.is_compressed = is_compressed;
+    }
+
+    fn is_compressed(&self) -> bool {
+        self.is_compressed
+    }
+}
+
+#[async_trait]
+impl<W: io::Write + AsyncWrite + Send> AsyncMysqlShim<W> for MysqlConn {
+    type Error = BaseRtError;
+
+    async fn on_prepare<'a>(
+        &'a mut self,
+        query: &'a str,
+        info: StatementMetaWriter<'a, W>,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn on_execute<'a>(
+        &'a mut self,
+        id: u32,
+        params: ParamParser<'a>,
+        results: QueryResultWriter<'a, W>,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn on_close<'a>(&'a mut self, stmt: u32)
+    where
+        W: 'async_trait,
+    {
+    }
+
+    async fn on_init<'a>(
+        &'a mut self,
+        schema: &'a str,
+        writer: InitWriter<'a, W>,
+    ) -> Result<(), Self::Error> {
+        let query = format!("USE {}", schema);
+        match BMS.run_commands(query, self) {
+            Ok(_) => Ok(writer.ok()?),
+            Err(e) => {
+                // TODO: Add access denied error
+                writer.error(
+                    ErrorKind::ER_BAD_DB_ERROR,
+                    format!("Can't access database {}", schema).as_bytes(),
+                )?;
+                Err(e)
+            }
+        }
+    }
+
+    async fn on_query<'a>(
+        &'a mut self,
+        query: &'a str,
+        results: QueryResultWriter<'a, W>,
+    ) -> Result<(), Self::Error> {
+        let res = BMS.run_commands(query.to_string(), self);
+        match res {
+            Ok(BaseCommandKind::Query(blks)) => write_blks(results, blks),
+            Ok(
+                BaseCommandKind::Create
+                | BaseCommandKind::Drop
+                | BaseCommandKind::Optimize
+                | BaseCommandKind::InsertFormatInlineValues
+                | BaseCommandKind::InsertFormatSelectValue,
+            ) => {
+                log::debug!("Query Success:1");
+                results.completed(0, 0)?;
+                Ok(())
+            }
+            Ok(
+                BaseCommandKind::InsertFormatInline(header, qtn, tid)
+                | BaseCommandKind::InsertFormatCSV(header, qtn, tid),
+            ) => {
+                todo!()
+            }
+            Ok(_) => Err(BaseRtError::UnsupportedFunctionality),
+            Err(e) => {
+                // log::info!("Return Err: {}", e);
+                Err(e)
+            }
+        }
+    }
+}
+
+fn write_blks<W: io::Write>(
+    results: QueryResultWriter<W>,
+    blks: Vec<RecordBatch>,
+) -> BaseRtResult<()> {
+    if blks.len() > 1 {
+        return Err(BaseRtError::UnexpectedMessage);
+    }
+    let blk = &blks[0];
+    let columns: Vec<Column> = blk
+        .schema()
+        .fields()
+        .iter()
+        .map(|c| Column {
+            table: "".to_string(),
+            column: c.name().to_owned(),
+            coltype: arrow_type_to_mysql_type(c.data_type()).unwrap(),
+            colflags: if matches!(
+                c.data_type(),
+                DataType::UInt16 | DataType::UInt32 | DataType::UInt64 | DataType::UInt8
+            ) {
+                ColumnFlags::UNSIGNED_FLAG
+            } else {
+                ColumnFlags::empty()
+            },
+        })
+        .collect();
+
+    let mut writer = results.start(&columns)?;
+    for row in 0..blk.num_rows() {
+        for col in blk.columns() {
+            match col.data_type() {
+                DataType::Int8 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::Int8Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::Int16 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::Int16Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::Int32 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::Int32Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::Int64 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::Int64Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::UInt8 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::UInt8Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::UInt16 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::UInt16Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::UInt32 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::UInt32Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::UInt64 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::UInt64Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::Float32 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::Float32Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::Float64 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::Float64Array>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::Timestamp32(_) => {
+                    todo!();
+                }
+                DataType::Date16 => {
+                    todo!();
+                }
+                DataType::Decimal(_, _) => {
+                    todo!();
+                }
+                DataType::LargeUtf8 => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::LargeStringArray>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                DataType::FixedSizeBinary(_) => {
+                    let val = col
+                        .as_any()
+                        .downcast_ref::<array::FixedSizeBinaryArray>()
+                        .unwrap()
+                        .value(row);
+                    log::debug!("Write result on row {}: {:?}", row, val);
+                    writer.write_col(val)?;
+                }
+                _ => return Err(BaseRtError::UnsupportedValueConversion),
+            }
+        }
+        writer.end_row()?;
+    }
+
+    Ok(writer.finish()?)
+}
+
+fn arrow_type_to_mysql_type(typ: &DataType) -> BaseRtResult<ColumnType> {
+    log::debug!("arrow_type_to_btype: {}", typ);
+    match typ {
+        DataType::Int8 | DataType::UInt8 => Ok(ColumnType::MYSQL_TYPE_TINY),
+        DataType::Int16 | DataType::UInt16 => Ok(ColumnType::MYSQL_TYPE_SHORT),
+        DataType::Int32 | DataType::UInt32 => Ok(ColumnType::MYSQL_TYPE_LONG),
+        DataType::Int64 | DataType::UInt64 => Ok(ColumnType::MYSQL_TYPE_LONGLONG),
+        DataType::Float32 => Ok(ColumnType::MYSQL_TYPE_FLOAT),
+        DataType::Float64 => Ok(ColumnType::MYSQL_TYPE_DOUBLE),
+        DataType::Timestamp32(_) => todo!(),
+        DataType::Date16 => Ok(ColumnType::MYSQL_TYPE_DATE),
+        DataType::Decimal(_, _) => Ok(ColumnType::MYSQL_TYPE_DECIMAL),
+        DataType::LargeUtf8 => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::FixedSizeBinary(len) => Ok(ColumnType::MYSQL_TYPE_TINY),
+        _ => Err(BaseRtError::UnsupportedConversionToBqlType),
+    }
+}

--- a/crates/runtime/src/types.rs
+++ b/crates/runtime/src/types.rs
@@ -1,0 +1,473 @@
+use std::{convert::TryFrom, fmt::Debug, intrinsics::copy_nonoverlapping, slice};
+
+use arrow::{array::LargeStringArray, datatypes::DataType, record_batch::RecordBatch};
+use base::{codec::encode_varint64, datetimes::TimeZoneId};
+
+use bytes::{Buf, BufMut, BytesMut};
+use client::prelude::{types::SqlType, ServerBlock};
+use meta::types::{BaseChunk, BqlType};
+
+use crate::errs::{BaseRtError, BaseRtResult};
+
+pub struct BaseColumn {
+    pub name: Vec<u8>,
+    pub data: BaseChunk,
+}
+
+#[derive(Default)]
+pub struct BaseDataBlock {
+    pub ncols: usize,
+    pub nrows: usize,
+    pub columns: Vec<BaseColumn>,
+}
+
+impl Debug for BaseDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BaseDataBlock")
+            .field("ncols", &self.ncols)
+            .field("nrows", &self.nrows)
+            .field("columns", &self.columns)
+            .finish()
+    }
+}
+
+impl BaseDataBlock {
+    pub fn reset(&mut self) {
+        self.ncols = 0;
+        self.nrows = 0;
+        self.columns = vec![];
+    }
+
+    #[inline(always)]
+    pub fn null_map_from_data(
+        btype: &BqlType,
+        offsets: Option<&Vec<u32>>,
+        data: &Vec<u8>,
+    ) -> Option<Vec<u8>> {
+        if !matches!(btype, BqlType::String) {
+            Some(
+                data.chunks(btype.size_in_usize().unwrap())
+                    .map(|c| if c.into_iter().all(|&b| b == 0) { 1 } else { 0 })
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            // Todo: test the performance
+            let offsets = offsets.as_ref().unwrap();
+            let null_map = offsets[..(offsets.len() - 1)]
+                .iter()
+                .map(|offset| {
+                    let offset = *offset as usize;
+                    if data[offset..offset + 1][0] == 0 {
+                        1
+                    } else {
+                        0
+                    }
+                })
+                .collect::<Vec<_>>();
+            Some(null_map)
+        }
+    }
+}
+
+fn arrow_type_to_btype(typ: &DataType) -> BaseRtResult<BqlType> {
+    log::debug!("arrow_type_to_btype: {}", typ);
+    match typ {
+        DataType::UInt8 => Ok(BqlType::UInt(8)),
+        DataType::UInt16 => Ok(BqlType::UInt(16)),
+        DataType::UInt32 => Ok(BqlType::UInt(32)),
+        DataType::UInt64 => Ok(BqlType::UInt(64)),
+        DataType::Int8 => Ok(BqlType::Int(8)),
+        DataType::Int16 => Ok(BqlType::Int(16)),
+        DataType::Int32 => Ok(BqlType::Int(32)),
+        DataType::Int64 => Ok(BqlType::Int(64)),
+        DataType::Float16 => Ok(BqlType::Float(16)),
+        DataType::Float32 => Ok(BqlType::Float(32)),
+        DataType::Float64 => Ok(BqlType::Float(64)),
+        DataType::Timestamp32(None) => Ok(BqlType::DateTime),
+        DataType::Timestamp32(Some(tz)) => Ok(BqlType::DateTimeTz(*tz)),
+        DataType::Date16 => Ok(BqlType::Date),
+        DataType::Decimal(p, s) => Ok(BqlType::Decimal(*p as u8, *s as u8)),
+        DataType::LargeUtf8 => Ok(BqlType::String),
+        DataType::FixedSizeBinary(len) => Ok(BqlType::FixedString(*len as u8)),
+        _ => Err(BaseRtError::UnsupportedConversionToBqlType),
+    }
+}
+
+impl TryFrom<RecordBatch> for BaseDataBlock {
+    type Error = BaseRtError;
+
+    fn try_from(res: RecordBatch) -> Result<Self, Self::Error> {
+        let mut blk = BaseDataBlock::default();
+        let sch = res.schema();
+        let fields = sch.fields();
+        let cols = res.columns();
+        let ncols = cols.len();
+        blk.ncols = ncols;
+        for i in 0..ncols {
+            let btype = arrow_type_to_btype(fields[i].data_type())?;
+            let name = fields[i].name().as_bytes().to_vec();
+            let col = &cols[i];
+            let cd = col.data();
+            // let array = col.as_any().downcast_ref::<array::Int64Array>().unwrap().values();
+            let buf = if matches!(btype, BqlType::String) {
+                &col.data().buffers()[1]
+            } else {
+                &col.data().buffers()[0]
+            };
+            // log::debug!("cd.get_array_memory_size(): {}", cd.get_array_memory_size());
+            let (len_in_bytes, offsets) = if matches!(btype, BqlType::String) {
+                let arr = col.as_any().downcast_ref::<LargeStringArray>().unwrap();
+                let ofs = arr
+                    .value_offsets()
+                    .last()
+                    .copied()
+                    .ok_or(BaseRtError::FailToUnwrapOpt)?;
+
+                (
+                    ofs as usize,
+                    Some(arr.value_offsets().iter().map(|o| *o as u32).collect()),
+                )
+            } else {
+                (btype.size_in_usize()? * col.len(), None)
+            };
+            let data = unsafe {
+                std::slice::from_raw_parts(buf.as_ptr(), len_in_bytes).to_vec()
+            };
+            blk.nrows = col.len(); //FIXME all rows are in same size
+
+            let null_map = if !matches!(btype, BqlType::String) {
+                if fields[i].is_nullable() {
+                    BaseDataBlock::null_map_from_data(&btype, offsets.as_ref(), &data)
+                } else {
+                    None
+                }
+            } else {
+                if fields[i].is_nullable() {
+                    BaseDataBlock::null_map_from_data(&btype, offsets.as_ref(), &data)
+                } else {
+                    None
+                }
+            };
+
+            blk.columns.push(BaseColumn {
+                name,
+                data: BaseChunk {
+                    btype,
+                    size: col.len(),
+                    // data: Vec::from_raw_parts(qcs.data, qclen_bytes, qclen_bytes),
+                    // data: Vec::<u8>::with_capacity(qclen_bytes),
+                    data,
+                    null_map,
+                    offset_map: offsets,
+                    // pub lc_dict_size: usize,
+                    lc_dict_data: None,
+                },
+            });
+        }
+        Ok(blk)
+    }
+}
+
+impl BaseColumn {
+    // block header:
+    // Initialize header from the index.
+    //    for (const auto & column : index_block_it->columns)
+    //    {
+    //        auto type = DataTypeFactory::instance().get(column.type);
+    //        header.insert(ColumnWithTypeAndName{ type, column.name });
+    //    }
+    ///NOTE insert/select needs this kind info to send to client firstly
+    pub fn new_block_header(name: Vec<u8>, typ: BqlType, is_nullable: bool) -> Self {
+        BaseColumn {
+            name,
+            data: BaseChunk {
+                btype: typ,
+                size: 0,
+                data: vec![],
+                null_map: if is_nullable { Some(vec![]) } else { None },
+                offset_map: None,
+                lc_dict_data: None,
+            },
+        }
+    }
+
+    #[inline]
+    pub fn get_name<'a>(&'a self) -> &'a str {
+        unsafe { std::str::from_utf8_unchecked(&self.name) }
+    }
+}
+
+pub trait BaseWriteAware {
+    fn write_varint(&mut self, value: u64);
+    fn write_varbytes(&mut self, value: &[u8]);
+}
+
+impl BaseWriteAware for BytesMut {
+    #[inline(always)]
+    fn write_varint(&mut self, value: u64) {
+        self.reserve(10); //FIXME
+        let buf =
+            unsafe { slice::from_raw_parts_mut(self.as_mut_ptr().add(self.len()), 10) };
+        let vi_len = encode_varint64(value, buf);
+        unsafe {
+            self.advance_mut(vi_len);
+        }
+    }
+
+    #[inline(always)]
+    fn write_varbytes(&mut self, value: &[u8]) {
+        let len = value.len();
+        self.reserve(10 + len); //FIXME
+        self.write_varint(len as u64);
+        // value.as_bytes().copy_to_slice()
+        unsafe {
+            copy_nonoverlapping(value.as_ptr(), self.as_mut_ptr().add(self.len()), len);
+            self.advance_mut(len);
+        }
+    }
+}
+
+pub trait BaseReadAware {
+    fn ensure_enough_bytes_to_read(
+        &mut self,
+        additional_space: usize,
+    ) -> BaseRtResult<()>;
+    fn read_varint(&mut self) -> BaseRtResult<u64>;
+    fn read_str<'a, 'b>(&mut self) -> BaseRtResult<&'b str>;
+    fn read_varbytes<'a, 'b>(&mut self) -> BaseRtResult<&'b [u8]>;
+    // fn read_fix<T>(&mut self) -> T;
+}
+
+impl BaseReadAware for BytesMut {
+    #[inline(always)]
+    fn ensure_enough_bytes_to_read(
+        &mut self,
+        additional_space: usize,
+    ) -> BaseRtResult<()> {
+        if self.len() >= additional_space {
+            Ok(())
+        } else {
+            Err(BaseRtError::IncompletedWireFormat)
+        }
+    }
+
+    #[inline(always)]
+    fn read_varint(&mut self) -> BaseRtResult<u64> {
+        if self.len() == 0 {
+            //FIXME unnecssary?
+            return Err(BaseRtError::IncompletedWireFormat);
+        }
+        // most varints are in practice fit in 1 byte
+        if self[0] < 0x80 {
+            let r = self[0] as u64;
+            self.advance(1);
+            return Ok(r);
+        } else {
+            // handle case of two bytes too
+            if self.len() <= 1 {
+                //FIXME unnecssary?
+                return Err(BaseRtError::IncompletedWireFormat);
+            }
+            if self[1] < 0x80 {
+                let r = (self[0] & 0x7f) as u64 | (self[1] as u64) << 7;
+                self.advance(2);
+                return Ok(r);
+            } else {
+                return read_raw_varint64_slow_bytesmut(self);
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn read_str<'a, 'b>(&mut self) -> BaseRtResult<&'b str> {
+        //FIXME one rust driver use arbitrary 128bit bytes as query_id?
+        unsafe { Ok(std::str::from_utf8_unchecked(self.read_varbytes()?)) }
+    }
+
+    #[inline(always)]
+    fn read_varbytes<'a, 'b>(&mut self) -> BaseRtResult<&'b [u8]> {
+        let len = self.read_varint()? as usize;
+        unsafe {
+            let ptr = self.as_ptr();
+            self.advance(len);
+            Ok(slice::from_raw_parts(ptr, len))
+        }
+    }
+}
+
+impl BaseReadAware for &[u8] {
+    #[inline(always)]
+    fn ensure_enough_bytes_to_read(
+        &mut self,
+        additional_space: usize,
+    ) -> BaseRtResult<()> {
+        if self.len() < additional_space {
+            Err(BaseRtError::IncompletedWireFormat)
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline(always)]
+    fn read_varint(&mut self) -> BaseRtResult<u64> {
+        if self.len() == 0 {
+            //FIXME unnecssary?
+            return Err(BaseRtError::IncompletedWireFormat);
+        }
+        // most varints are in practice fit in 1 byte
+        if self[0] < 0x80 {
+            let r = self[0] as u64;
+            self.advance(1);
+            return Ok(r);
+        } else {
+            // handle case of two bytes too
+            if self.len() <= 1 {
+                //FIXME unnecssary?
+                return Err(BaseRtError::IncompletedWireFormat);
+            }
+            if self[1] < 0x80 {
+                let r = (self[0] & 0x7f) as u64 | (self[1] as u64) << 7;
+                self.advance(2);
+                return Ok(r);
+            } else {
+                return read_raw_varint64_slow(self);
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn read_str<'a, 'b>(&mut self) -> BaseRtResult<&'b str> {
+        //FIXME one rust driver use arbitrary 128bit bytes as query_id?
+        unsafe { Ok(std::str::from_utf8_unchecked(self.read_varbytes()?)) }
+    }
+
+    #[inline(always)]
+    fn read_varbytes<'a, 'b>(&mut self) -> BaseRtResult<&'b [u8]> {
+        let len = self.read_varint()? as usize;
+        self.ensure_enough_bytes_to_read(len)?;
+        unsafe {
+            let ptr = self.as_ptr();
+            self.advance(len);
+            Ok(slice::from_raw_parts(ptr, len))
+        }
+    }
+}
+
+#[inline(always)]
+fn read_raw_varint64_slow_bytesmut(bs: &mut BytesMut) -> BaseRtResult<u64> {
+    let mut r: u64 = 0;
+    let mut i = 0;
+    loop {
+        if i == 10 {
+            return Err(BaseRtError::InvalidWireFormatInVarInt(r));
+        }
+        let b = bs[i];
+        // TODO: may overflow if i == 9
+        r = r | (((b & 0x7f) as u64) << (i * 7));
+        i += 1;
+        if b < 0x80 {
+            bs.advance(i);
+            return Ok(r);
+        }
+    }
+}
+
+#[inline(always)]
+fn read_raw_varint64_slow(bs: &mut &[u8]) -> BaseRtResult<u64> {
+    let mut r: u64 = 0;
+    let mut i = 0;
+    loop {
+        if i == 10 {
+            return Err(BaseRtError::InvalidWireFormatInVarInt(r));
+        }
+        let b = bs[i];
+        // TODO: may overflow if i == 9
+        r = r | (((b & 0x7f) as u64) << (i * 7));
+        i += 1;
+        if b < 0x80 {
+            bs.advance(i);
+            return Ok(r);
+        }
+    }
+}
+
+// TODO FIXME: The best approach is to unify the server and client block definitions
+// to avoid conversions
+#[inline]
+fn sqltype_to_bqltype(sqltype: SqlType) -> BqlType {
+    match sqltype {
+        SqlType::UInt8 => BqlType::UInt(8),
+        SqlType::UInt16 => BqlType::UInt(16),
+        SqlType::UInt32 => BqlType::UInt(32),
+        SqlType::UInt64 => BqlType::UInt(64),
+        SqlType::Int8 => BqlType::Int(8),
+        SqlType::Int16 => BqlType::Int(16),
+        SqlType::Int32 => BqlType::Int(32),
+        SqlType::Int64 => BqlType::Int(64),
+        SqlType::String => BqlType::String,
+        SqlType::FixedString(i) => BqlType::FixedString(i as u8),
+        SqlType::Float32 => BqlType::Float(32),
+        SqlType::Float64 => BqlType::Float(64),
+        SqlType::Date => BqlType::Date,
+        SqlType::DateTime(tz) => match tz {
+            Some(tz) => {
+                BqlType::DateTimeTz(TimeZoneId(TimeZoneId::calc_offset_of_tz(tz)))
+            }
+            None => BqlType::DateTime,
+        },
+        SqlType::DateTime64(id, tz) => {
+            BqlType::DateTimeTz(TimeZoneId(TimeZoneId::calc_offset_of_tz(tz)))
+        }
+        SqlType::Decimal(x, y) => BqlType::Decimal(x, y),
+        SqlType::LowCardinality => BqlType::LowCardinalityTinyText,
+        SqlType::Uuid => BqlType::Uuid,
+        SqlType::Ipv4
+        | SqlType::Ipv6
+        | SqlType::Enum8
+        | SqlType::Enum16
+        | SqlType::Array => unimplemented!(),
+    }
+}
+
+// TODO FIXME: The best approach is to unify the server and client block definitions
+// to avoid conversions
+impl From<ServerBlock> for BaseDataBlock {
+    fn from(b: ServerBlock) -> Self {
+        let mut new_blk = BaseDataBlock::default();
+        let nrows = b.rows as usize;
+
+        new_blk.ncols = b.columns.len();
+        new_blk.nrows = nrows;
+
+        for mut c in b.columns {
+            let btype = sqltype_to_bqltype(c.header.field.get_sqltype());
+            let offset_map = c.data.offset_map();
+            let data = unsafe { c.data.into_bytes() };
+            let field = c.header.field;
+            let null_map = if field.is_nullable() {
+                if !matches!(btype, BqlType::String) {
+                    BaseDataBlock::null_map_from_data(&btype, None, &data)
+                } else {
+                    BaseDataBlock::null_map_from_data(&btype, offset_map.as_ref(), &data)
+                }
+            } else {
+                None
+            };
+            let chunk = BaseChunk {
+                btype,
+                size: nrows,
+                data,
+                null_map,
+                offset_map,
+                lc_dict_data: None,
+            };
+            let column = BaseColumn {
+                name: c.header.name.as_bytes().to_vec(),
+                data: chunk,
+            };
+
+            new_blk.columns.push(column);
+        }
+        new_blk
+    }
+}

--- a/crates/runtime/src/types.rs
+++ b/crates/runtime/src/types.rs
@@ -197,6 +197,15 @@ impl BaseColumn {
     }
 }
 
+pub trait BaseServerConn {
+    fn get_query_id(&self) -> &str;
+    fn set_query_id(&mut self, query_id: String);
+    fn get_db(&self) -> &str;
+    fn set_db(&mut self, db: String);
+    fn set_compressed(&mut self, is_compressed: bool);
+    fn is_compressed(&self) -> bool;
+}
+
 pub trait BaseWriteAware {
     fn write_varint(&mut self, value: u64);
     fn write_varbytes(&mut self, value: &[u8]);

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -18,12 +18,16 @@ use meta::{
 };
 
 use crate::{
-    ch::blocks::Block,
     errs::{BaseRtError, BaseRtResult},
     mgmt::BMS,
+    types::BaseDataBlock,
 };
 
-pub fn write_block(blk: &mut Block, tab_ins: &str, tid_ins: Id) -> BaseRtResult<()> {
+pub fn write_block(
+    blk: &mut BaseDataBlock,
+    tab_ins: &str,
+    tid_ins: Id,
+) -> BaseRtResult<()> {
     debug_assert!(tab_ins.len() > 0);
     debug_assert!(tid_ins > 0);
 
@@ -64,7 +68,7 @@ pub fn write_block(blk: &mut Block, tab_ins: &str, tid_ins: Id) -> BaseRtResult<
 
 fn gen_parts_by_ptk_names(
     ptks: meta::store::sys::IVec,
-    blk: &Block,
+    blk: &BaseDataBlock,
     tab_ins: &str,
     tid_ins: u64,
 ) -> Result<HashMap<u64, Vec<(u32, u32)>>, BaseRtError> {
@@ -239,7 +243,7 @@ fn gather_into_blob_buf(
 }
 
 #[inline(always)]
-fn has_blob_type_column(blk: &Block) -> bool {
+fn has_blob_type_column(blk: &BaseDataBlock) -> bool {
     for i in 0..blk.ncols {
         let col = &blk.columns[i];
         let cchk = &col.data;
@@ -253,7 +257,7 @@ fn has_blob_type_column(blk: &Block) -> bool {
 
 #[inline(always)]
 fn write_part(
-    blk: &Block,
+    blk: &BaseDataBlock,
     ptk: u64,
     idxs: Vec<(u32, u32)>,
     ms: &MetaStore,
@@ -342,7 +346,7 @@ fn dump_buf(fd: u32, offset_in_bytes: usize, pt_len_in_bytes: usize, buf: *const
 //TODO slow path, to boost the performance when we want
 // #[inline(always)]
 fn write_part_locked(
-    blk: &Block,
+    blk: &BaseDataBlock,
     ptk: u64,
     idxs: Vec<(u32, u32)>,
     ms: &MetaStore,
@@ -425,7 +429,7 @@ mod unit_tests {
         with_timer_print,
     };
     use basejit::builtins::to_fn1;
-    use baselog::{Config, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
+    use baselog::{ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
     use meta::{
         confs::Conf,
         types::{BaseChunk, BqlType, ColumnInfo, EngineType, Table, TableInfo},
@@ -438,7 +442,7 @@ mod unit_tests {
     };
     use walkdir::WalkDir;
 
-    use crate::{ch::blocks::Column, errs::BaseRtResult, mgmt::BMS};
+    use crate::{errs::BaseRtResult, mgmt::BMS, types::BaseColumn};
 
     use super::*;
 
@@ -609,8 +613,8 @@ mod unit_tests {
         let cdata1: Vec<u32> = (0..col_len as u32).collect();
         let cdata2: Vec<u32> = cdata1.iter().map(|e| 2 * (*e) + 1354291200).collect();
 
-        let mut blk = Block::default();
-        let col1: Column = Column {
+        let mut blk = BaseDataBlock::default();
+        let col1: BaseColumn = BaseColumn {
             name: b"col1".to_vec(),
             data: BaseChunk {
                 btype: BqlType::UInt(32),
@@ -621,7 +625,7 @@ mod unit_tests {
                 lc_dict_data: None,
             },
         };
-        let col2: Column = Column {
+        let col2: BaseColumn = BaseColumn {
             name: b"col2".to_vec(),
             data: BaseChunk {
                 btype: BqlType::UInt(32),

--- a/crates/runtime/tests/system_tests.rs
+++ b/crates/runtime/tests/system_tests.rs
@@ -1,8 +1,10 @@
 use baselog::{Config, LevelFilter, TermLogger, TerminalMode};
 use meta::{confs::Conf, types::BqlType};
 use runtime::{
+    ch::protocol::ConnCtx,
     errs::{BaseRtError, BaseRtResult},
     mgmt::{BaseCommandKind, BaseMgmtSys},
+    types::BaseServerConn,
 };
 use test_utils::prepare_empty_tmp_dir;
 
@@ -31,7 +33,7 @@ fn prepare_bms<'a>() -> BaseRtResult<BaseMgmtSys<'a>> {
 #[test]
 fn test_run_commands() -> BaseRtResult<()> {
     let bms = prepare_bms()?;
-    let mut cctx = Default::default();
+    let mut cctx = ConnCtx::default();
 
     let res = bms.run_commands("".to_string(), &mut cctx);
     assert!(matches!(res, Err(_)));
@@ -90,9 +92,9 @@ fn test_run_commands() -> BaseRtResult<()> {
 
     assert!(matches!(res, BaseCommandKind::Create));
 
-    assert_eq!("default", cctx.current_db);
+    assert_eq!("default", cctx.get_db());
     let res = bms.run_commands("use xxx_123".to_string(), &mut cctx)?;
-    assert_eq!("xxx_123", cctx.current_db);
+    assert_eq!("xxx_123", cctx.get_db());
 
     let res = bms.run_commands(
         "insert into default.payment11 values".to_string(),


### PR DESCRIPTION
Current runtime crate uses some definitions from its `ch` module. These include definitions for the data block (`Block`) and data structure for the connection state (`ConnCtx`). These definitions include data specific to the ClickHouse protocol, which makes it infeasible for other protocols, e.g., MySQL.

This PR removes this dependency by introducing two protocol-agnostic definitions:

* `struct BaseDataBlock`: This struct contains the exact data that TB's runtime requires, moving protocol-specific data to CH's `Block`.
* `trait BaseServerConn`: This trait contains the connection information that TB's runtime needs to know, e.g, current database id. CH's `ConnCtx` implements this trait.

The two commits in this PR changes a considerable amount of code changes. But most of them are reorganization of code. Please feel free to leave comments.