### PR TITLE
REFACTOR(runtime): use RecordBatch to represent query results

### DIFF
--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -14,6 +14,7 @@ itoa = "0.4"
 btoi = "0.4"
 libc = "0.2"
 base = { path = "../base" }
+arrow = { path = "../arrow" }
 
 [dependencies.serde]
 features = ["derive"]

--- a/crates/meta/src/errs.rs
+++ b/crates/meta/src/errs.rs
@@ -97,6 +97,9 @@ pub enum MetaError {
     #[error(transparent)]
     WrappingBaseError(#[from] base::errs::BaseError),
 
+    #[error(transparent)]
+    WrappingArrowError(#[from] arrow::error::ArrowError),
+
     #[error("No enough space for cache")]
     NoEnoughCacheSpace,
 

--- a/crates/runtime/src/ch/messages.rs
+++ b/crates/runtime/src/ch/messages.rs
@@ -1,9 +1,10 @@
 use bytes::{Buf, BufMut, BytesMut};
 use lzzzz::lz4;
+use std::convert::TryFrom;
 use std::str;
 
 use crate::mgmt::{BaseCommandKind, BMS, WRITE};
-use crate::types::{BaseReadAware, BaseWriteAware};
+use crate::types::{BaseDataBlock, BaseReadAware, BaseWriteAware};
 
 use super::protocol::{StageKind, LZ4_COMPRESSION_METHOD};
 use crate::ch::blocks::{Block, EMPTY_CLIENT_BLK_BYTES};
@@ -341,7 +342,7 @@ fn response_query(
     match res {
         Ok(BaseCommandKind::Query(blks)) => {
             for blk in blks {
-                let ch_blk = Block::from(blk);
+                let ch_blk = Block::from(BaseDataBlock::try_from(blk)?);
                 if compression == 1 {
                     let _bs = cctx.get_raw_blk_resp();
                     ch_blk.get_block_header().encode_to(wb, Some(_bs))?;

--- a/crates/runtime/src/read.rs
+++ b/crates/runtime/src/read.rs
@@ -3,13 +3,23 @@ use crate::{
     mgmt::BMS,
     types::{BaseColumn, BaseDataBlock},
 };
-use client::prelude::{errors::Error as ClientError, PoolBuilder};
-use engine::remote;
-use engine::types::QueryState;
+use arrow::{
+    array::ArrayData, buffer::Buffer, datatypes::DataType, record_batch::RecordBatch,
+};
+use arrow::{array::*, datatypes::Field, datatypes::Schema};
+use base::datetimes::TimeZoneId;
+use client::{
+    prelude::{errors::Error as ClientError, PoolBuilder, ServerBlock},
+    types::SqlType,
+};
+use engine::{remote, types::QueryState};
 use lang::parse::{Pair, RemoteAddr, RemoteDbType, RemoteTableInfo, Rule};
-use meta::store::{parts::PartStore, sys::MetaStore};
+use meta::{
+    store::{parts::PartStore, sys::MetaStore},
+    types::btype_to_arrow_type,
+};
 use mysql::{OptsBuilder, Pool as MyPool};
-use std::{convert::TryFrom, time::Instant};
+use std::{sync::Arc, time::Instant};
 
 pub fn query(
     ms: &MetaStore,
@@ -17,7 +27,7 @@ pub fn query(
     query_id: &str,
     current_db: &str,
     p: Pair<Rule>,
-) -> BaseRtResult<Vec<BaseDataBlock>> {
+) -> BaseRtResult<Vec<RecordBatch>> {
     let timer = Instant::now();
     let query_id = query_id.replace("-", "_");
     let raw_query = p.as_str().to_string();
@@ -36,14 +46,7 @@ pub fn query(
 
     log::debug!("query run time cost {:?}", timer.elapsed());
 
-    let mut blks = Vec::with_capacity(res.len());
-    for rb in res {
-        let blk = BaseDataBlock::try_from(rb)?;
-
-        blks.push(blk);
-    }
-
-    Ok(blks)
+    Ok(res)
 }
 
 const DEFAULT_REMOTE_PORT: u16 = 9528;
@@ -149,7 +152,7 @@ pub fn remote_query(
     remote_tb_info: RemoteTableInfo,
     raw_query: &str,
     is_local: bool,
-) -> BaseRtResult<Vec<BaseDataBlock>> {
+) -> BaseRtResult<Vec<RecordBatch>> {
     match remote_tb_info.database_type {
         RemoteDbType::ClickHouse | RemoteDbType::TensorBase => {
             update_remote_db_pools(&remote_tb_info)?;
@@ -177,7 +180,9 @@ pub fn remote_query(
                 .map(|addr| {
                     let pool = &*ps.get(&addr).unwrap();
                     match remote::run(pool, &sql) {
-                        Ok(blks) => Ok(blks.into_iter().map(|b| b.into())),
+                        Ok(blks) => Ok(blks
+                            .into_iter()
+                            .map(|b| serverblock_to_recordbatch(b).unwrap())),
                         Err(err) => Err(BaseRtError::WrappingEngineError(err)),
                     }
                 })
@@ -195,7 +200,7 @@ pub fn remote_query(
                 .into_iter()
                 .map(|addr| {
                     let pool = &*ps.get(&addr).unwrap();
-                    match remote::mysql_run(pool, &sql) {
+                    let block = match remote::mysql_run(pool, &sql) {
                         Ok((ncols, nrows, cols)) => {
                             let mut blk = BaseDataBlock {
                                 ncols,
@@ -212,11 +217,232 @@ pub fn remote_query(
                             Ok(blk)
                         }
                         Err(err) => Err(err),
-                    }
+                    };
+                    basedatablock_to_recordbatch(block?)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
             Ok(blks)
         }
     }
+}
+
+// TODO FIXME: The best approach is to unify the server and client block definitions
+// to avoid conversions
+#[inline]
+fn sqltype_to_arrowtype(sqltype: SqlType) -> DataType {
+    match sqltype {
+        SqlType::UInt8 => DataType::UInt8,
+        SqlType::UInt16 => DataType::UInt16,
+        SqlType::UInt32 => DataType::UInt32,
+        SqlType::UInt64 => DataType::UInt64,
+        SqlType::Int8 => DataType::Int8,
+        SqlType::Int16 => DataType::Int16,
+        SqlType::Int32 => DataType::Int32,
+        SqlType::Int64 => DataType::Int64,
+        SqlType::String => DataType::LargeUtf8,
+        SqlType::FixedString(i) => DataType::LargeBinary,
+        SqlType::Float32 => DataType::Float32,
+        SqlType::Float64 => DataType::Float64,
+        SqlType::Date => DataType::Date16,
+        SqlType::DateTime(tz) => match tz {
+            Some(tz) => {
+                DataType::Timestamp32(Some(TimeZoneId(TimeZoneId::calc_offset_of_tz(tz))))
+            }
+            None => DataType::Timestamp32(None),
+        },
+        SqlType::DateTime64(id, tz) => {
+            DataType::Timestamp32(Some(TimeZoneId(TimeZoneId::calc_offset_of_tz(tz))))
+        }
+        SqlType::Decimal(x, y) => DataType::Decimal(x.into(), y.into()),
+        SqlType::LowCardinality => DataType::UInt8,
+        SqlType::Ipv4
+        | SqlType::Ipv6
+        | SqlType::Uuid
+        | SqlType::Enum8
+        | SqlType::Enum16
+        | SqlType::Array => unimplemented!(),
+    }
+}
+
+// TODO FIXME: The best approach is to unify the server and client block definitions
+// to avoid conversions
+fn serverblock_to_recordbatch(b: ServerBlock) -> BaseRtResult<RecordBatch> {
+    let mut cols: Vec<Arc<dyn Array>> = Vec::new();
+    let mut fields = Vec::new();
+    let nrows = b.rows as usize;
+
+    for mut c in b.columns {
+        let arrow_type = sqltype_to_arrowtype(c.header.field.get_sqltype());
+
+        fields.push(Field::new(
+            &c.header.name,
+            arrow_type.clone(),
+            c.header.field.is_nullable(),
+        ));
+
+        let data = unsafe { c.data.into_bytes() };
+
+        let buf = Buffer::from_slice_ref(&data);
+
+        let data = if matches!(arrow_type, DataType::LargeUtf8) {
+            let offset_map = c.data.offset_map().unwrap(); // Must have offset map
+            let offset_map = offset_map
+                .into_iter()
+                .map(|x| x.into())
+                .collect::<Vec<i64>>();
+            let buf_om = Buffer::from_slice_ref(&offset_map);
+
+            ArrayData::builder(arrow_type.clone())
+                .len(nrows)
+                .add_buffer(buf_om)
+                .add_buffer(buf)
+                .build()
+        } else {
+            ArrayData::builder(arrow_type.clone())
+                .len(nrows)
+                .add_buffer(buf)
+                .build()
+        };
+        match arrow_type {
+            DataType::Int8 => {
+                cols.push(Arc::new(Int8Array::from(data)));
+            }
+            DataType::Int16 => {
+                cols.push(Arc::new(Int16Array::from(data)));
+            }
+            DataType::Int32 => {
+                cols.push(Arc::new(Int32Array::from(data)));
+            }
+            DataType::Int64 => {
+                cols.push(Arc::new(Int64Array::from(data)));
+            }
+            DataType::UInt8 => {
+                cols.push(Arc::new(UInt8Array::from(data)));
+            }
+            DataType::UInt16 => {
+                cols.push(Arc::new(UInt16Array::from(data)));
+            }
+            DataType::UInt32 => {
+                cols.push(Arc::new(UInt32Array::from(data)));
+            }
+            DataType::UInt64 => {
+                cols.push(Arc::new(UInt64Array::from(data)));
+            }
+            DataType::Float32 => {
+                cols.push(Arc::new(Float32Array::from(data)));
+            }
+            DataType::Float64 => {
+                cols.push(Arc::new(Float64Array::from(data)));
+            }
+            DataType::Timestamp32(_) => {
+                cols.push(Arc::new(Timestamp32Array::from(data)));
+            }
+            DataType::Date16 => {
+                cols.push(Arc::new(Date16Array::from(data)));
+            }
+            DataType::Decimal(_, _) => {
+                cols.push(Arc::new(DecimalArray::from(data)));
+            }
+            DataType::LargeUtf8 => {
+                cols.push(Arc::new(GenericStringArray::<i64>::from(data)));
+            }
+            DataType::FixedSizeBinary(_) => {
+                cols.push(Arc::new(FixedSizeBinaryArray::from(data)));
+            }
+            // TODO!!!
+            _ => return Err(BaseRtError::FailToUnwrapOpt),
+        }
+    }
+
+    let schema = Schema::new(fields);
+
+    Ok(RecordBatch::try_new(Arc::new(schema), cols)?)
+}
+
+fn basedatablock_to_recordbatch(b: BaseDataBlock) -> BaseRtResult<RecordBatch> {
+    let mut cols: Vec<Arc<dyn Array>> = Vec::new();
+    let mut fields = Vec::new();
+    let nrows = b.nrows as usize;
+
+    for c in b.columns {
+        let arrow_type = btype_to_arrow_type(c.data.btype)?;
+
+        fields.push(Field::new(c.get_name(), arrow_type.clone(), true));
+
+        let buf = Buffer::from_slice_ref(&c.data.data);
+
+        let data = if matches!(arrow_type, DataType::LargeUtf8) {
+            if let Some(offset_map) = c.data.offset_map {
+                let buf_om = Buffer::from_slice_ref(&offset_map);
+
+                ArrayData::builder(arrow_type.clone())
+                    .len(nrows)
+                    .add_buffer(buf_om)
+                    .add_buffer(buf)
+                    .build()
+            } else {
+                // Must give an offset map
+                todo!();
+            }
+        } else {
+            ArrayData::builder(arrow_type.clone())
+                .len(nrows)
+                .add_buffer(buf)
+                .build()
+        };
+        match arrow_type {
+            DataType::Int8 => {
+                cols.push(Arc::new(Int8Array::from(data)));
+            }
+            DataType::Int16 => {
+                cols.push(Arc::new(Int16Array::from(data)));
+            }
+            DataType::Int32 => {
+                cols.push(Arc::new(Int32Array::from(data)));
+            }
+            DataType::Int64 => {
+                cols.push(Arc::new(Int64Array::from(data)));
+            }
+            DataType::UInt8 => {
+                cols.push(Arc::new(UInt8Array::from(data)));
+            }
+            DataType::UInt16 => {
+                cols.push(Arc::new(UInt16Array::from(data)));
+            }
+            DataType::UInt32 => {
+                cols.push(Arc::new(UInt32Array::from(data)));
+            }
+            DataType::UInt64 => {
+                cols.push(Arc::new(UInt64Array::from(data)));
+            }
+            DataType::Float32 => {
+                cols.push(Arc::new(Float32Array::from(data)));
+            }
+            DataType::Float64 => {
+                cols.push(Arc::new(Float64Array::from(data)));
+            }
+            DataType::Timestamp32(_) => {
+                cols.push(Arc::new(Timestamp32Array::from(data)));
+            }
+            DataType::Date16 => {
+                cols.push(Arc::new(Date16Array::from(data)));
+            }
+            DataType::Decimal(_, _) => {
+                cols.push(Arc::new(DecimalArray::from(data)));
+            }
+            DataType::LargeUtf8 => {
+                cols.push(Arc::new(GenericStringArray::<i64>::from(data)));
+            }
+            DataType::FixedSizeBinary(_) => {
+                cols.push(Arc::new(FixedSizeBinaryArray::from(data)));
+            }
+            // TODO!!!
+            _ => return Err(BaseRtError::FailToUnwrapOpt),
+        }
+    }
+
+    let schema = Schema::new(fields);
+
+    Ok(RecordBatch::try_new(Arc::new(schema), cols)?)
 }

--- a/crates/runtime/tests/system_tests.rs
+++ b/crates/runtime/tests/system_tests.rs
@@ -4,7 +4,7 @@ use runtime::{
     ch::protocol::ConnCtx,
     errs::{BaseRtError, BaseRtResult},
     mgmt::{BaseCommandKind, BaseMgmtSys},
-    types::BaseServerConn,
+    types::{BaseDataBlock, BaseServerConn},
 };
 use test_utils::prepare_empty_tmp_dir;
 
@@ -32,6 +32,7 @@ fn prepare_bms<'a>() -> BaseRtResult<BaseMgmtSys<'a>> {
 
 #[test]
 fn test_run_commands() -> BaseRtResult<()> {
+    use std::convert::TryInto;
     let bms = prepare_bms()?;
     let mut cctx = ConnCtx::default();
 
@@ -73,10 +74,11 @@ fn test_run_commands() -> BaseRtResult<()> {
     assert!(matches!(res, BaseCommandKind::Query(_)));
     if let BaseCommandKind::Query(vbc) = res {
         assert!(vbc.len() == 1);
-        assert!(vbc[0].ncols == 1);
+        let vbc: BaseDataBlock = vbc[0].to_owned().try_into().unwrap();
+        assert!(vbc.ncols == 1);
         // assert!(vbc[0].nrows == 1);
-        assert!(vbc[0].columns[0].data.btype == BqlType::String);
-        assert!(vbc[0].columns[0].data.data.len() > 0);
+        assert!(vbc.columns[0].data.btype == BqlType::String);
+        assert!(vbc.columns[0].data.data.len() > 0);
     }
 
     let res = bms.run_commands(


### PR DESCRIPTION
Current runtime code uses `BaseDataBlock` to represent query results, which is a simple wrapper around the `Vec<u8>` buffer. This straightforward representation does not enable easy element-wise data indexing, which is required for performing type conversion for the MySQL server.

This commit instead uses Arrow::RecordBatch to store query results, which provides good element-wise access API on top of the Arrow data format used by TB.

Note that our original `BaseDataBlock` is still useful as a "fast path". Where we do not need element-wise data access (e.g., INSERT queries), we can still use `BaseDataBlock` to directly store the data buffer.
