### PR TITLE
CI: use cache to make CI builds faster

### DIFF
--- a/.github/workflows/base_checks.yml
+++ b/.github/workflows/base_checks.yml
@@ -22,6 +22,8 @@ jobs:
         override: true
         components: rustfmt, clippy
     - uses: actions/checkout@v2
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v1
     - name: TensorBase Build
       run: cargo build
     - name: TensorBase unit tests

--- a/.github/workflows/base_integ_sanity_checks.yml
+++ b/.github/workflows/base_integ_sanity_checks.yml
@@ -34,6 +34,8 @@ jobs:
       with:
             toolchain: nightly-2021-09-01
             override: true
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v1
     - name: TensorBase Run server
       run: |
            mkdir ${{ github.workspace }}/tb_data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ lto = 'thin'
 # lto = 'fat'
 # codegen-units = 1
 # incremental = false
+
+[profile.dev]
+# Disabling debug info speeds up builds a bunch
+debug = 0


### PR DESCRIPTION
This change uses Swatinem/rust-cache to store TB's dependencies (e.g., `./target` directory) between CI builds. This makes the CI process faster. From my own tests, the workflow execution time is reduced from ~12 minutes to ~7 minutes.

The `debug` build flag is disabled because doing so will significantly reduce the size of the cache, as well as make the compilation faster.

This change is inspired by a [blog post](https://matklad.github.io/2021/09/04/fast-rust-builds.html) on how rust-analyzer kept their CI time under 8 minutes.