### PR TITLE
FIX(test, mysql_server): clean schema and data directory before running mysql server tests

### DIFF
--- a/.github/workflows/base_integ_sanity_checks.yml
+++ b/.github/workflows/base_integ_sanity_checks.yml
@@ -65,6 +65,11 @@ jobs:
     - name: Kill TensorBase CH server
       run: kill $(lsof -t -i:${{ env.SERVER_PORT }})
 
+    - name: Clean schema and data files
+      run: |
+        rm -r ${{ github.workspace }}/tb_schema/*
+        rm -r ${{ github.workspace }}/tb_data/*
+
     - name: TensorBase Run MySQL server
       run: |
         cargo run --bin mysql_server -- -s "$BASE_CONF" &

--- a/crates/tests_integ/tests/sanity_checks_mysql.rs
+++ b/crates/tests_integ/tests/sanity_checks_mysql.rs
@@ -3,7 +3,6 @@ use common::get_tb_mysql_pool;
 use mysql::prelude::*;
 
 #[tokio::test]
-#[ignore = "Disable temporarily to get CI passed"]
 async fn tests_mysql_integ_stress_test_ddl() {
     let pool = get_tb_mysql_pool();
     let mut conn = pool.get_conn().unwrap();


### PR DESCRIPTION
In the integ_test, we originally used `kill` to shut down the ClickHouse server before we start MySQL tests. This may cause data inconsistency issues because some metadata stored in `sled`'s pagecache may not have been flushed to disk when shut down happens. The previous CI failures is probably caused by this.

This commit cleans the schema and data directory before MySQL test starts to avoid data inconsistency problem. In the long term, a more graceful shutdown mechanism should be implemented for TB.

I ran the CI workflow on my fork for multiple times and the failures no longer happen now.