### PR TITLE
FEAT(mysql_server): Add support for float and decimal types

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -29,6 +29,7 @@ datafusion = { path = "../datafusion", features = ["simd"] }
 server_mysql = { path = "../server_mysql" }
 tokio = { version = "1.0", features = ["io-util", "io-std"] }
 async-trait = "0.1.40"
+bigdecimal = "0.3.0"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -1173,6 +1173,23 @@ fn parse_literal_as_bytes(lit: &str, btyp: BqlType) -> BaseRtResult<Vec<u8>> {
             let v = ut.to_le_bytes();
             rt.extend(&v);
         }
+        BqlType::Float(bits) => match bits {
+            64 => {
+                let v = lit
+                    .parse::<f64>()
+                    .map_err(|_e| BaseRtError::InsertIntoValueParsingError)?
+                    .to_le_bytes();
+                rt.extend(&v);
+            }
+            32 => {
+                let v = lit
+                    .parse::<f32>()
+                    .map_err(|_e| BaseRtError::InsertIntoValueParsingError)?
+                    .to_le_bytes();
+                rt.extend(&v);
+            }
+            _ => return Err(BaseRtError::UnsupportedValueConversion),
+        },
         BqlType::String => {
             todo!()
         }

--- a/crates/tests_integ/tests/sanity_checks_mysql.rs
+++ b/crates/tests_integ/tests/sanity_checks_mysql.rs
@@ -125,7 +125,6 @@ async fn tests_mysql_integ_basic_test_insert_select() {
 }
 
 #[tokio::test]
-#[ignore = "MySQL server currently does not support decimal types"]
 async fn tests_mysql_integ_basic_insert_float() {
     let pool = get_tb_mysql_pool();
     let mut conn = pool.get_conn().unwrap();


### PR DESCRIPTION
1. Use standard library `parse` methods to parse input floating point data.
2. Use `BigDecimal` crate to parse input decimal data. For input, this commit uses `BigDecimal` crate to parse and store Decimal data. For output, I manually did the type conversion between Decimal's underlying signed integer representation to the String output format.
     