### PR TITLE
FEAT(mysql_server): add support for Datetime and Date types

### DIFF
--- a/crates/base/src/datetimes.rs
+++ b/crates/base/src/datetimes.rs
@@ -160,7 +160,7 @@ pub fn div_mod_floor<T: Integer>(x: T, y: T) -> (T, T) {
 }
 
 #[inline(always)]
-fn add_tz_offset(unixtime: i32, tz_offset: i32) -> i32 {
+pub fn add_tz_offset(unixtime: i32, tz_offset: i32) -> i32 {
     let offset = tz_offset;
     unixtime + offset
 }

--- a/crates/tests_integ/tests/sanity_checks_mysql.rs
+++ b/crates/tests_integ/tests/sanity_checks_mysql.rs
@@ -1,4 +1,6 @@
 mod common;
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
 use common::get_tb_mysql_pool;
 use mysql::prelude::*;
 use mysql_common::bigdecimal::BigDecimal;
@@ -253,8 +255,43 @@ async fn tests_mysql_integ_basic_insert_decimal64() {
 }
 
 #[tokio::test]
-#[ignore = "MySQL server currently does not support date types"]
-async fn tests_mysql_integ_basic_insert_date() {}
+async fn tests_mysql_integ_basic_insert_date() {
+    let pool = get_tb_mysql_pool();
+    let mut conn = pool.get_conn().unwrap();
+
+    conn.query_drop("create database if not exists test_db")
+        .unwrap();
+    conn.query_drop("use test_db").unwrap();
+
+    conn.query_drop(format!("DROP TABLE IF EXISTS test_tab_date"))
+        .unwrap();
+    conn.query_drop(format!("CREATE TABLE test_tab_date(a Date)"))
+        .unwrap();
+
+    let data_a = vec![Utc.ymd(2010, 10, 20), Utc.ymd(2020, 1, 7)];
+    let checks = vec!["2010-10-20", "2020-01-07"];
+    for &a in &data_a {
+        conn.query_drop(format!(
+            "insert into test_tab_date values ('{}')",
+            a.naive_utc()
+        ))
+        .unwrap();
+    }
+
+    {
+        let sql = "select a from test_tab_date";
+        let mut query_result = conn.query_iter(sql).unwrap();
+
+        let mut i = 0;
+        while let Some(block) = query_result.next() {
+            let row = block.unwrap();
+
+            let res: NaiveDate = row.get(0).unwrap();
+            assert_eq!(res.to_string(), checks[i]);
+            i += 1;
+        }
+    }
+}
 
 #[tokio::test]
 async fn tests_mysql_integ_basic_insert_string() {
@@ -504,8 +541,56 @@ async fn tests_mysql_integ_cast_simple_datatype() {
 }
 
 #[tokio::test]
-#[ignore = "MySQL server currently does not support date types"]
-async fn tests_mysql_integ_date_cast() {}
+async fn tests_mysql_integ_date_cast() {
+    let pool = get_tb_mysql_pool();
+    let mut conn = pool.get_conn().unwrap();
+
+    conn.query_drop("create database if not exists test_db")
+        .unwrap();
+    conn.query_drop("use test_db").unwrap();
+
+    conn.query_drop(format!("DROP TABLE IF EXISTS test_tab_date"))
+        .unwrap();
+    conn.query_drop(format!("CREATE TABLE test_tab_date(a Date)"))
+        .unwrap();
+
+    let data_a = vec![Utc.ymd(2010, 10, 20), Utc.ymd(2020, 1, 7)];
+    let checks = vec!["2010-10-20", "2020-01-07"];
+    for &a in &data_a {
+        conn.query_drop(format!(
+            "insert into test_tab_date values ('{}')",
+            a.naive_utc()
+        ))
+        .unwrap();
+    }
+
+    {
+        let sql = "select a from test_tab_date";
+        let mut query_result = conn.query_iter(sql).unwrap();
+
+        let mut i = 0;
+        while let Some(block) = query_result.next() {
+            let row = block.unwrap();
+
+            println!("{:?}", row);
+            let res: NaiveDate = row.get(0).unwrap();
+            assert_eq!(res.to_string(), checks[i]);
+            i += 1;
+        }
+    }
+
+    {
+        let sql = "select count(1) from test_tab_date where a < '2011-11-11' ";
+        let mut query_result = conn.query_iter(sql).unwrap();
+
+        while let Some(block) = query_result.next() {
+            let row = block.unwrap();
+            println!("{:?}", row);
+            let res: u64 = row.get(0).unwrap();
+            assert_eq!(res, 1);
+        }
+    }
+}
 
 #[tokio::test]
 #[ignore = "MySQL server currently does not support remote functions"]
@@ -658,9 +743,241 @@ async fn tests_mysql_integ_insert_into_remote_function() {
     }
 }
 
+fn apply_offset(
+    data_naive: &Vec<NaiveDateTime>,
+    tz: impl TimeZone,
+) -> Vec<DateTime<Utc>> {
+    data_naive
+        .iter()
+        .map(|b| Utc.from_utc_datetime(&tz.from_local_datetime(b).unwrap().naive_utc()))
+        .collect()
+}
+
 #[tokio::test]
-#[ignore = "MySQL server currently does not support date types"]
-async fn tests_mysql_integ_date_time_functions() {}
+async fn tests_mysql_integ_date_time_functions() {
+    let pool = get_tb_mysql_pool();
+    let mut conn = pool.get_conn().unwrap();
+
+    conn.query_drop("create database if not exists test_db")
+        .unwrap();
+    conn.query_drop("use test_db").unwrap();
+
+    conn.query_drop(format!("DROP TABLE IF EXISTS test_tab_date"))
+        .unwrap();
+    conn.query_drop(format!(
+        "CREATE TABLE test_tab_date( \
+            a Date, \
+            b DateTime, \
+            c String, \
+            ct String, \
+            d Int64, \
+            dt Int64, \
+            e DateTime('Etc/GMT+5'), \
+            f DateTime('-11:45') \
+        )"
+    ))
+    .unwrap();
+
+    let data_a = vec![
+        Utc.ymd(2010, 1, 1),
+        Utc.ymd(2011, 2, 28),
+        Utc.ymd(2012, 2, 29),
+        Utc.ymd(2012, 3, 4),
+        Utc.ymd(2021, 8, 31),
+        Utc.ymd(2021, 6, 27),
+    ];
+
+    let data_a_datetime: Vec<_> = data_a
+        .iter()
+        .map(|date| {
+            Tz::Etc__GMTMinus8
+                .from_local_date(&date.naive_utc())
+                .unwrap()
+                .and_hms(0, 0, 0)
+        })
+        .collect();
+
+    let data_naive = vec![
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+        NaiveDate::from_ymd(2011, 2, 28).and_hms(2, 5, 6),
+        NaiveDate::from_ymd(2012, 2, 29).and_hms(23, 59, 59),
+        NaiveDate::from_ymd(2012, 3, 4).and_hms(5, 6, 7),
+        NaiveDate::from_ymd(2021, 8, 31).and_hms(14, 32, 3),
+        NaiveDate::from_ymd(2021, 6, 27).and_hms(17, 44, 32),
+    ];
+
+    let data_b = data_naive
+        .iter()
+        .map(|t| Utc.from_utc_datetime(t))
+        .collect::<Vec<_>>();
+    let data_e = data_b.clone();
+    let data_f = data_b.clone();
+
+    let data_b_check = apply_offset(&data_naive, Tz::Etc__GMTMinus8);
+    let data_e_check = apply_offset(&data_naive, Tz::Etc__GMTPlus5);
+    let data_f_check = apply_offset(&data_naive, FixedOffset::west(11 * 3600 + 45 * 60));
+
+    let data_c = vec![
+        "2010-1-1",
+        "2011-2-28",
+        "2012-02-29",
+        "2012-03-4",
+        "2021-8-31",
+        "2021-6-27",
+    ];
+
+    let data_ct = vec![
+        "2010-01-01 01:01:01",
+        "2011-02-28 02:05:06",
+        "2012-02-29 23:59:59",
+        "2012-03-04 05:06:07",
+        "2021-08-31 14:32:03",
+        "2021-06-27 17:44:32",
+    ];
+
+    let data_d = vec![14610_i64, 15033, 15399, 15403, 18870, 18805];
+    let data_dt: Vec<_> = data_b.iter().map(DateTime::timestamp).collect();
+
+    let years = vec![2010, 2011, 2012, 2012, 2021, 2021];
+    let months = vec![1, 2, 2, 3, 8, 6];
+    let quarters = vec![1, 1, 1, 1, 3, 2];
+    let day_of_years = vec![1, 59, 60, 64, 243, 178];
+    let day_of_months = vec![1, 28, 29, 4, 31, 27];
+    let day_of_weeks = vec![5, 1, 3, 7, 2, 7];
+    let hours = vec![1, 2, 23, 5, 14, 17];
+    let minutes = vec![1, 5, 59, 6, 32, 44];
+    let seconds = vec![1, 6, 59, 7, 3, 32];
+
+    for i in 0..6 {
+        conn.query_drop(format!(
+            "insert into test_tab_date values ('{}', '{}', '{}', '{}', {}, {}, '{}', '{}')",
+            data_a[i].naive_local(),
+            data_b[i].naive_local(),
+            data_c[i],
+            data_ct[i],
+            data_d[i],
+            data_dt[i],
+            data_e[i].naive_local(),
+            data_f[i].naive_local()
+        ))
+        .unwrap();
+    }
+    {
+        let sql = "select \
+            toYear(a), toYear(b), toYear(e), toYear(f), \
+            toMonth(a), toMonth(b), toMonth(e), toMonth(f), \
+            toDayOfYear(a), toDayOfYear(b), toDayOfYear(e), toDayOfYear(f), \
+            toDayOfMonth(a), toDayOfMonth(b), toDayOfMonth(e), toDayOfMonth(f), \
+            toDayOfWeek(a), toDayOfWeek(b), toDayOfWeek(e), toDayOfWeek(f), \
+            toQuarter(a), toQuarter(b), toQuarter(e), toQuarter(f), \
+            toHour(b), toMinute(b), toSecond(b), \
+            toHour(e), toMinute(e), toSecond(e), \
+            toHour(f), toMinute(f), toSecond(f), \
+            toDate(a), toDate(b), toDate(c), toDate(d), toDate(e), toDate(f), \
+            toDateTime(a), toDateTime(b), toDateTime(ct), \
+            toDateTime(dt), toDateTime(e), toDateTime(f) \
+        from test_tab_date";
+        let mut query_result = conn.query_iter(sql).unwrap();
+
+        let mut i = 0;
+        while let Some(block) = query_result.next() {
+            let row = block.unwrap();
+            println!("{:?}", row);
+            let mut iter = 0..;
+            let year_a: u16 = row.get(iter.next().unwrap()).unwrap();
+            let year_b: u16 = row.get(iter.next().unwrap()).unwrap();
+            let year_e: u16 = row.get(iter.next().unwrap()).unwrap();
+            let year_f: u16 = row.get(iter.next().unwrap()).unwrap();
+            let month_a: u8 = row.get(iter.next().unwrap()).unwrap();
+            let month_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let month_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let month_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_year_a: u16 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_year_b: u16 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_year_e: u16 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_year_f: u16 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_month_a: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_month_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_month_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_month_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_week_a: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_week_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_week_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let day_of_week_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let quarter_a: u8 = row.get(iter.next().unwrap()).unwrap();
+            let quarter_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let quarter_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let quarter_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let hour_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let minute_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let second_b: u8 = row.get(iter.next().unwrap()).unwrap();
+            let hour_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let minute_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let second_e: u8 = row.get(iter.next().unwrap()).unwrap();
+            let hour_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let minute_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let second_f: u8 = row.get(iter.next().unwrap()).unwrap();
+            let to_date_a: NaiveDate = row.get(iter.next().unwrap()).unwrap();
+            let to_date_b: NaiveDate = row.get(iter.next().unwrap()).unwrap();
+            let to_date_c: NaiveDate = row.get(iter.next().unwrap()).unwrap();
+            let to_date_d: NaiveDate = row.get(iter.next().unwrap()).unwrap();
+            let to_date_e: NaiveDate = row.get(iter.next().unwrap()).unwrap();
+            let to_date_f: NaiveDate = row.get(iter.next().unwrap()).unwrap();
+            let datetime_a: NaiveDateTime = row.get(iter.next().unwrap()).unwrap();
+            let datetime_b: NaiveDateTime = row.get(iter.next().unwrap()).unwrap();
+            let datetime_c: NaiveDateTime = row.get(iter.next().unwrap()).unwrap();
+            let datetime_d: NaiveDateTime = row.get(iter.next().unwrap()).unwrap();
+            let datetime_e: NaiveDateTime = row.get(iter.next().unwrap()).unwrap();
+            let datetime_f: NaiveDateTime = row.get(iter.next().unwrap()).unwrap();
+            assert_eq!(year_a, years[i]);
+            assert_eq!(year_b, years[i]);
+            assert_eq!(year_e, years[i]);
+            assert_eq!(year_f, years[i]);
+            assert_eq!(month_a, months[i]);
+            assert_eq!(month_b, months[i]);
+            assert_eq!(month_e, months[i]);
+            assert_eq!(month_f, months[i]);
+            assert_eq!(day_of_year_a, day_of_years[i]);
+            assert_eq!(day_of_year_b, day_of_years[i]);
+            assert_eq!(day_of_year_e, day_of_years[i]);
+            assert_eq!(day_of_year_f, day_of_years[i]);
+            assert_eq!(day_of_month_a, day_of_months[i]);
+            assert_eq!(day_of_month_b, day_of_months[i]);
+            assert_eq!(day_of_month_e, day_of_months[i]);
+            assert_eq!(day_of_month_f, day_of_months[i]);
+            assert_eq!(day_of_week_a, day_of_weeks[i]);
+            assert_eq!(day_of_week_b, day_of_weeks[i]);
+            assert_eq!(day_of_week_e, day_of_weeks[i]);
+            assert_eq!(day_of_week_f, day_of_weeks[i]);
+            assert_eq!(quarter_a, quarters[i]);
+            assert_eq!(quarter_b, quarters[i]);
+            assert_eq!(quarter_e, quarters[i]);
+            assert_eq!(quarter_f, quarters[i]);
+            assert_eq!(hour_b, hours[i]);
+            assert_eq!(minute_b, minutes[i]);
+            assert_eq!(second_b, seconds[i]);
+            assert_eq!(hour_e, hours[i]);
+            assert_eq!(minute_e, minutes[i]);
+            assert_eq!(second_e, seconds[i]);
+            assert_eq!(hour_f, hours[i]);
+            assert_eq!(minute_f, minutes[i]);
+            assert_eq!(second_f, seconds[i]);
+            assert_eq!(to_date_a, data_a[i].naive_utc());
+            assert_eq!(to_date_b, data_a[i].naive_utc());
+            assert_eq!(to_date_c, data_a[i].naive_utc());
+            assert_eq!(to_date_d, data_a[i].naive_utc());
+            assert_eq!(to_date_e, data_a[i].naive_utc());
+            assert_eq!(to_date_f, data_a[i].naive_utc());
+            assert_eq!(datetime_a, data_a_datetime[i].naive_utc());
+            assert_eq!(datetime_b, data_b_check[i].naive_utc());
+            assert_eq!(datetime_c, data_b_check[i].naive_utc());
+            assert_eq!(datetime_d, data_b[i].naive_utc());
+            assert_eq!(datetime_e, data_e_check[i].naive_utc());
+            assert_eq!(datetime_f, data_f_check[i].naive_utc());
+            i += 1;
+        }
+    }
+}
 
 #[tokio::test]
 #[ignore = "MySQL server currently does not support uuid types"]


### PR DESCRIPTION
This commit enhances the support for parsing Date and Datetime literals in SQL queries. It also adds support for writing Date and Dateime values in MySQL outputs.

Three more test cases in sanity_checks_mysql can now get passed after this change.