### PR TITLE
FEAT(runtime): support primary key data deduplication

### DIFF
--- a/crates/lang/src/errs.rs
+++ b/crates/lang/src/errs.rs
@@ -57,4 +57,7 @@ pub enum LangError {
 
     #[error("Conflict condition when partition key pxpr parsing")]
     PartitionKeyExprParsingConflict,
+
+    #[error("Unsupported primary key parsing")]
+    PrimaryKeyParsingUnsupported,
 }

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -436,7 +436,7 @@ impl CreateTabContext {
                         col.1.is_primary_key = true;
                         match col.1.data_type {
                             // TODO: more type support
-                            BqlType::UInt(_) => {}
+                            BqlType::UInt(_) | BqlType::Date | BqlType::DateTime => {}
                             _ => {
                                 return Err(LangError::PrimaryKeyParsingUnsupported);
                             }

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -434,6 +434,13 @@ impl CreateTabContext {
                         ti.primary_keys.push_str(col.0.as_str());
                         ti.primary_keys.push(',');
                         col.1.is_primary_key = true;
+                        match col.1.data_type {
+                            // TODO: more type support
+                            BqlType::UInt(_) => {}
+                            _ => {
+                                return Err(LangError::PrimaryKeyParsingUnsupported);
+                            }
+                        }
                     }
                     _ => return Err(LangError::UnsupportedLangFeatureError),
                 };

--- a/crates/lang/src/parse.rs
+++ b/crates/lang/src/parse.rs
@@ -436,7 +436,10 @@ impl CreateTabContext {
                         col.1.is_primary_key = true;
                         match col.1.data_type {
                             // TODO: more type support
-                            BqlType::UInt(_) | BqlType::Date | BqlType::DateTime => {}
+                            BqlType::UInt(_)
+                            | BqlType::Date
+                            | BqlType::DateTime
+                            | BqlType::FixedString(_) => {}
                             _ => {
                                 return Err(LangError::PrimaryKeyParsingUnsupported);
                             }

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -13,6 +13,8 @@ num-traits = "0.2"
 itoa = "0.4"
 btoi = "0.4"
 libc = "0.2"
+dashmap = "4.0"
+roaring = "0.7.0"
 base = { path = "../base" }
 arrow = { path = "../arrow" }
 

--- a/crates/meta/src/errs.rs
+++ b/crates/meta/src/errs.rs
@@ -86,6 +86,9 @@ pub enum MetaError {
     #[error("Can not find part error")]
     CanNotFindPartError,
 
+    #[error("Unsupported primary key type error")]
+    UnsupportedPrimaryKeyTypeError,
+
     // #[error("Error when getting fd size from ps")]
     // GetFdSizeError,
     #[error("TransactionError [{0}] happened")]

--- a/crates/meta/src/store/sys.rs
+++ b/crates/meta/src/store/sys.rs
@@ -720,7 +720,7 @@ impl MetaStore {
                                 PrimaryKeyContainer::RoaringBitMap(RoaringBitmap::new()),
                             );
                         }
-                        BqlType::String => {
+                        BqlType::FixedString(_) => {
                             self.tabs_pkc.insert(
                                 tid,
                                 PrimaryKeyContainer::HashSet(HashSet::new()),
@@ -804,7 +804,7 @@ impl MetaStore {
                     PrimaryKeyContainer::RoaringBitMap(RoaringBitmap::new()),
                 );
             }
-            BqlType::String => {
+            BqlType::FixedString(_) => {
                 self.tabs_pkc
                     .insert(tid, PrimaryKeyContainer::HashSet(HashSet::new()));
             }
@@ -889,6 +889,17 @@ impl MetaStore {
                 if let PrimaryKeyContainer::RoaringBitMap(rbm) = pkc {
                     for i in 0..nr {
                         rbm.insert(col_data[i] as u32);
+                    }
+                }
+            }
+            BqlType::FixedString(n) => {
+                let col_data =
+                    unsafe { std::str::from_utf8_unchecked(&col_data) }.to_string();
+                let n = n as usize;
+                if let PrimaryKeyContainer::HashSet(hs) = pkc {
+                    for i in 0..nr {
+                        let val = &col_data[i * n..(i + 1) * n];
+                        hs.insert((*val).to_owned());
                     }
                 }
             }

--- a/crates/meta/src/store/sys.rs
+++ b/crates/meta/src/store/sys.rs
@@ -708,6 +708,18 @@ impl MetaStore {
                                 return Err(MetaError::UnsupportedPrimaryKeyTypeError);
                             }
                         },
+                        BqlType::Date => {
+                            self.tabs_pkc.insert(
+                                tid,
+                                PrimaryKeyContainer::RoaringBitMap(RoaringBitmap::new()),
+                            );
+                        }
+                        BqlType::DateTime => {
+                            self.tabs_pkc.insert(
+                                tid,
+                                PrimaryKeyContainer::RoaringBitMap(RoaringBitmap::new()),
+                            );
+                        }
                         BqlType::String => {
                             self.tabs_pkc.insert(
                                 tid,
@@ -780,6 +792,18 @@ impl MetaStore {
                     return Err(MetaError::UnsupportedPrimaryKeyTypeError);
                 }
             },
+            BqlType::Date => {
+                self.tabs_pkc.insert(
+                    tid,
+                    PrimaryKeyContainer::RoaringBitMap(RoaringBitmap::new()),
+                );
+            }
+            BqlType::DateTime => {
+                self.tabs_pkc.insert(
+                    tid,
+                    PrimaryKeyContainer::RoaringBitMap(RoaringBitmap::new()),
+                );
+            }
             BqlType::String => {
                 self.tabs_pkc
                     .insert(tid, PrimaryKeyContainer::HashSet(HashSet::new()));
@@ -852,6 +876,22 @@ impl MetaStore {
                     return Err(MetaError::UnsupportedPrimaryKeyTypeError);
                 }
             },
+            BqlType::Date => {
+                let col_data = shape_slice::<u16>(col_data);
+                if let PrimaryKeyContainer::RoaringBitMap(rbm) = pkc {
+                    for i in 0..nr {
+                        rbm.insert(col_data[i] as u32);
+                    }
+                }
+            }
+            BqlType::DateTime => {
+                let col_data = shape_slice::<u32>(col_data);
+                if let PrimaryKeyContainer::RoaringBitMap(rbm) = pkc {
+                    for i in 0..nr {
+                        rbm.insert(col_data[i] as u32);
+                    }
+                }
+            }
             _ => {
                 return Err(MetaError::UnsupportedPrimaryKeyTypeError);
             }

--- a/crates/meta/src/types.rs
+++ b/crates/meta/src/types.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::Ref,
     cell::RefMut,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     mem,
     ops::{Deref, DerefMut},
     slice,
@@ -13,6 +13,7 @@ use base::bytes_cat;
 use base::datetimes::TimeZoneId;
 use base::strings::BytesTrim;
 use num_traits::PrimInt;
+use roaring::{RoaringBitmap, RoaringTreemap};
 
 use crate::errs::MetaError;
 use crate::errs::MetaResult;
@@ -89,6 +90,13 @@ impl Default for EngineType {
     fn default() -> Self {
         EngineType::Default
     }
+}
+
+pub enum PrimaryKeyContainer {
+    HashSet(HashSet<String>),
+    RoaringBitMap(RoaringBitmap),
+    RoaringTreeMap(RoaringTreemap),
+    None,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]

--- a/crates/runtime/src/errs.rs
+++ b/crates/runtime/src/errs.rs
@@ -42,6 +42,9 @@ pub enum BaseRtError {
     #[error("Unsupported partition key type")]
     UnsupportedPartitionKeyType,
 
+    #[error("Unsupported primary key type")]
+    UnsupportedPrimaryKeyType,
+
     #[error("Command parsing error")]
     CommandParsingError,
 
@@ -221,6 +224,7 @@ impl BaseRtError {
             BaseRtError::InsertIntoValueParsingError => 413,
             BaseRtError::ShouldNotReachHere => 414,
             BaseRtError::MultiplePrimaryKeyNotSupported => 415,
+            BaseRtError::UnsupportedPrimaryKeyType => 416,
         }
     }
 }

--- a/crates/runtime/src/mgmt.rs
+++ b/crates/runtime/src/mgmt.rs
@@ -875,6 +875,7 @@ impl<'a> BaseMgmtSys<'a> {
         let tid_opt = ms.tid_by_qname(qtn.as_str());
         match tid_opt {
             Some(tid) => {
+                ms.clear_pkc_by_tid(tid)?;
                 //remove PartStore data
                 let cids = ms.get_column_ids(qtn.as_str())?;
                 ps.acquire_lock(tid)?;

--- a/crates/runtime/src/write.rs
+++ b/crates/runtime/src/write.rs
@@ -358,6 +358,22 @@ fn deduplicate_by_primary_key(
                 }
             }
         }
+        meta::types::BqlType::FixedString(n) => {
+            let cdata_pk =
+                unsafe { std::str::from_utf8_unchecked(&cdata_pk) }.to_string();
+            let n = *n as usize;
+            if let PrimaryKeyContainer::HashSet(hs) = pkc {
+                for i in 0..nr {
+                    let val_str = &cdata_pk[i * n..(i + 1) * n];
+                    let val = (*val_str).to_owned();
+                    if hs.contains(&val) {
+                        insert_mark[i] = 0;
+                    } else {
+                        hs.insert(val);
+                    }
+                }
+            }
+        }
         _ => {
             return Err(BaseRtError::UnsupportedPrimaryKeyType);
         }

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -1342,6 +1342,168 @@ async fn tests_integ_partition_prune() -> errors::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn tests_integ_primary_key_uint32() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists mt")).await?;
+    conn.execute(format!("create table mt(a UInt32 primary key, b UInt32)"))
+        .await?;
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            println!("cnt:{}", cnt);
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            println!("cnt:{}", cnt);
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tests_integ_primary_key_uint16() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists mt")).await?;
+    conn.execute(format!("create table mt(a UInt16 primary key, b UInt32)"))
+        .await?;
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tests_integ_primary_key_uint8() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists mt")).await?;
+    conn.execute(format!("create table mt(a UInt8 primary key, b UInt32)"))
+        .await?;
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tests_integ_primary_key_uint64() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists mt")).await?;
+    conn.execute(format!("create table mt(a UInt64 primary key, b UInt32)"))
+        .await?;
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute(format!("insert into mt values(1,1),(1,2)"))
+        .await?;
+    {
+        let sql = "select * from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
 // #[tokio::test]
 // async fn test_insert_large_block() -> errors::Result<()> {
 //     let pool = get_pool();

--- a/crates/tests_integ/tests/sanity_checks.rs
+++ b/crates/tests_integ/tests/sanity_checks.rs
@@ -1535,7 +1535,113 @@ async fn tests_integ_primary_key_truncate() -> errors::Result<()> {
         }
     }
 
-    // conn.execute("drop database if exists test_db").await?;
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tests_integ_primary_key_date() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists mt")).await?;
+    conn.execute(format!("create table mt(a Date primary key)"))
+        .await?;
+    let data_a = vec![Utc.ymd(2021, 9, 1), Utc.ymd(2021, 9, 1)];
+    let block = { Block::new("mt").add("a", data_a.clone()) };
+
+    let mut insert = conn.insert(&block).await?;
+    insert.commit().await?;
+
+    drop(insert);
+    {
+        let sql = "select a from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+    let block = { Block::new("mt").add("a", data_a.clone()) };
+
+    let mut insert = conn.insert(&block).await?;
+    insert.commit().await?;
+
+    drop(insert);
+    {
+        let sql = "select a from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tests_integ_primary_key_datetime() -> errors::Result<()> {
+    let pool = get_pool();
+    let mut conn = pool.connection().await?;
+
+    conn.execute("create database if not exists test_db")
+        .await?;
+    conn.execute("use test_db").await?;
+
+    conn.execute(format!("drop table if exists mt")).await?;
+    conn.execute(format!("create table mt(a DateTime primary key)"))
+        .await?;
+    let data_naive = vec![
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+        NaiveDate::from_ymd(2010, 1, 1).and_hms(1, 1, 1),
+    ];
+
+    let data_a = data_naive
+        .iter()
+        .map(|t| Utc.from_utc_datetime(t))
+        .collect::<Vec<_>>();
+    let block = { Block::new("mt").add("a", data_a.clone()) };
+
+    let mut insert = conn.insert(&block).await?;
+    insert.commit().await?;
+
+    drop(insert);
+    {
+        let sql = "select a from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+    let block = { Block::new("mt").add("a", data_a.clone()) };
+
+    let mut insert = conn.insert(&block).await?;
+    insert.commit().await?;
+
+    drop(insert);
+    {
+        let sql = "select a from mt";
+        let mut query_result = conn.query(sql).await?;
+
+        while let Some(block) = query_result.next().await? {
+            let cnt = block.row_count();
+            assert_eq!(cnt, 1);
+        }
+    }
+
+    conn.execute("drop database if exists test_db").await?;
     Ok(())
 }
 


### PR DESCRIPTION
Signed-off-by: nautaa <870284156@qq.com>
relate issue: #266
This PR supports primary key data deduplication. 
primary key type:
* UInt8/UInt16/UInt32/UInt64
* Date
* DateTime
* FixString

Taking into account the consistency of pk meta, the method of metadata reconstruction from data is adopted.
- [x] Other data types.
- [x] The recovery of PK metadata from disk.